### PR TITLE
Removing of invisible views implemented as method in RobotiumUtils

### DIFF
--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Checker.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Checker.java
@@ -40,6 +40,7 @@ class Checker {
 	public <T extends CompoundButton> boolean isButtonChecked(Class<T> expectedClass, int index)
 	{
 		ArrayList<T> list = viewFetcher.getCurrentViews(expectedClass);
+		list=RobotiumUtils.removeInvisibleViews(list);
 		if(index < 0 || index > list.size()-1)
 			Assert.assertTrue("No " + expectedClass.getSimpleName() + " with index " + index + " is found", false);
 		return (list.get(index)).isChecked();

--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Clicker.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Clicker.java
@@ -338,7 +338,9 @@ class Clicker {
 	public <T extends View> void clickOn(Class<T> viewClass, int index) {
 		waiter.waitForIdle();
 		try {
-			clickOnScreen(viewFetcher.getCurrentViews(viewClass).get(index));
+			ArrayList<T> views=viewFetcher.getCurrentViews(viewClass);
+			views=RobotiumUtils.removeInvisibleViews(views);
+			clickOnScreen(views.get(index));
 		} catch (IndexOutOfBoundsException e) {
 			Assert.assertTrue("Index is not valid!", false);
 		}

--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/RobotiumUtils.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/RobotiumUtils.java
@@ -1,8 +1,11 @@
 package com.jayway.android.robotium.solo;
 
+import java.util.ArrayList;
+
 import junit.framework.Assert;
 import android.app.Instrumentation;
 import android.view.KeyEvent;
+import android.view.View;
 import android.widget.EditText;
 
 
@@ -67,7 +70,25 @@ class RobotiumUtils {
 		}
 	}
 
-
+	/**
+	 * Removes invisible Views
+	 * 
+	 * @param viewList ArrayList with Views that is being checked for invisible View objects.
+	 * @return Filtered ArrayList with no invisible elements.
+	 */
+	
+	public static <T extends View> ArrayList<T> removeInvisibleViews(ArrayList<T> viewList) {
+		ArrayList<T> tmpViewList = new ArrayList<T>(viewList.size());
+		for (T view : viewList) {
+			if (view != null && view.getVisibility() != View.GONE
+					&& view.getVisibility() != View.INVISIBLE) {
+				tmpViewList.add(view);
+			}
+		}
+		return tmpViewList;
+	}
+	
+	
 	
 
 }

--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/TextEnterer.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/TextEnterer.java
@@ -35,24 +35,6 @@ class TextEnterer{
         this.waiter = waiter;
     }
 
-	/**
-	 * Removes invisible EditText Views
-	 * 
-	 * @param editTextViews
-	 *            ArrayList with instances of EditText that is being checked for
-	 *            invisible EditText objects.
-	 * @return Filtered ArrayList with no invisible elements.
-	 */
-	private ArrayList<EditText> removeInvisibleEditText(ArrayList<EditText> editTextViews) {
-		ArrayList<EditText> newEditTextViews = new ArrayList<EditText>(editTextViews.size());
-		for (EditText editText : editTextViews) {
-			if (editText != null && editText.getVisibility() != View.GONE
-					&& editText.getVisibility() != View.INVISIBLE) {
-				newEditTextViews.add(editText);
-			}
-		}
-		return newEditTextViews;
-	}
 
 	
 	 /**
@@ -68,7 +50,7 @@ class TextEnterer{
     	try{
     		ArrayList<EditText> editTextViews= viewFetcher.getCurrentViews(EditText.class);
     		// remove invisible edits from list prevents them to be indexed.
-    		editTextViews = removeInvisibleEditText(editTextViews);
+    		editTextViews = RobotiumUtils.removeInvisibleViews(editTextViews);
     		final EditText	editText = editTextViews.get(index);
     		if(editText != null){
     			final String previousText = editText.getText().toString();

--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/ViewFetcher.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/ViewFetcher.java
@@ -173,6 +173,7 @@ class ViewFetcher {
 		sleeper.sleep();
 		inst.waitForIdleSync();
 		ArrayList<T> views = getCurrentViews(classToFilterBy);
+		views=RobotiumUtils.removeInvisibleViews(views);
 		T view = null;
 		try{
 			view = views.get(index);


### PR DESCRIPTION
I removed the today earlier checked in method for removing invisible EditText and replaced it with a generic method in RobotiumUtils. Also changed methods in Clicker, Checker, ViewFetcher and TextEnterer to remove invisible Views when accessing a View using an index. 
