### PR TITLE
Fix ActivityMonitor leak in ActivityUtils

### DIFF
--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/ActivityUtils.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/ActivityUtils.java
@@ -227,13 +227,22 @@ class ActivityUtils {
 	
 	public void finalize() throws Throwable {
 		try {
+			// Finish all opened activities
 			for (int i = activityList.size()-1; i >= 0; i--) {
 				activityList.get(i).finish();
 				sleeper.sleep(100);
 			}
+
+			// Finish the initial activity, pressing Back for good measure
 			getCurrentActivity().finish();
-			inst.sendKeyDownUpSync(KeyEvent.KEYCODE_BACK);
+			try {
+				inst.sendKeyDownUpSync(KeyEvent.KEYCODE_BACK);
+			} catch (SecurityException ignored) {
+				// Guard against lack of INJECT_EVENT permission
+			}
 			activityList.clear();
+
+			// Remove the monitor added during startup
 			if (activityMonitor != null) {
 				inst.removeMonitor(activityMonitor);
 			}


### PR DESCRIPTION
During ActivityUtils finalisation, remove the ActivityMonitor that gets added to Instrumentation at startup.
Also catch previously-ignored SecurityException when attempting to press Back button.
