### PR TITLE
Reduce memory leaks

### DIFF
--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Asserter.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Asserter.java
@@ -92,12 +92,14 @@ class Asserter {
 		boolean found = false;
 		assertCurrentActivity(message, expectedClass);
 		Activity activity = activityUtils.getCurrentActivity(false);
-		for (int i = 0; i < activityUtils.getAllOpenedActivities().size() - 1; i++) {
-			String instanceString = activityUtils.getAllOpenedActivities().get(i).toString();
-			if (instanceString.equals(activity.toString()))
-				found = true;
+		for (Activity openActivity: activityUtils.getAllOpenedActivities()) {
+			if(openActivity != null){
+				String instanceString = openActivity.toString();
+				if (instanceString.equals(activity.toString()))
+					found = true;
+			}
 		}
-			Assert.assertNotSame(message + ", isNewInstance: actual and ", isNewInstance, found);
+		Assert.assertNotSame(message + ", isNewInstance: actual and ", isNewInstance, found);
 	}
 	
 	/**

--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Solo.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Solo.java
@@ -1,6 +1,8 @@
 package com.jayway.android.robotium.solo;
 
 import java.util.ArrayList;
+import java.util.Collection;
+
 import junit.framework.Assert;
 import android.app.Activity;
 import android.app.Instrumentation;
@@ -16,12 +18,12 @@ import android.widget.EditText;
 import android.widget.GridView;
 import android.widget.ImageButton;
 import android.widget.ImageView;
+import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.RadioButton;
 import android.widget.ScrollView;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.ListView;
 import android.widget.TimePicker;
 import android.widget.ToggleButton;
 
@@ -508,11 +510,13 @@ public class Solo {
 	/**
 	 * Returns an ArrayList of all the opened/active activities.
 	 * 
+	 * Using this might create a memory leak.
+	 * 
 	 * @return an ArrayList of all the opened/active activities
 	 *
 	 */
 	
-	public ArrayList<Activity> getAllOpenedActivities()
+	public Collection<Activity> getAllOpenedActivities()
 	{
 		return activitiyUtils.getAllOpenedActivities();
 	}


### PR DESCRIPTION
Hi Renas,

In my project Collectionista, as I've told you before, I was running into OutOfMemoryErrors near the end of the full test. I did a memory analysis and it turned out Solo was keeping all my Activities in memory via the activityList. I finally solved it with a "solo = null" in the tearDown() of each test. But on the way, I changed some Robotium code to use weak references, which should make it easier for the gc to free memory. I haven't been able to fully test this, as I'm still wrestling with some problems with Robotium-2.1 (I'm upgrading from 1.7.1, the vanilla Robotium also exhibits these). I'd like to hear your thoughts on this piece of code and would like to see it in the next version.

Cheers,

pjv (ezelspinguin at gmail dot com)
