### PR TITLE
getCurrentActivity() returns an incorrect activity after calling goBack()

### DIFF
--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/RobotiumUtils.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/RobotiumUtils.java
@@ -28,21 +28,6 @@ class RobotiumUtils {
         this.sleeper = sleeper;
     }
    
-	
-	/**
-	 * Simulates pressing the hardware back key.
-	 * 
-	 */
-	
-	public void goBack() {
-		sleeper.sleep();
-		try {
-			inst.sendKeyDownUpSync(KeyEvent.KEYCODE_BACK);
-			sleeper.sleep();
-		} catch (Throwable e) {}
-	}
-	
-	
 	/**
 	 * Tells Robotium to send a key code: Right, Left, Up, Down, Enter or other.
 	 * @param keycode the key code to be sent. Use {@link KeyEvent#KEYCODE_ENTER}, {@link KeyEvent#KEYCODE_MENU}, {@link KeyEvent#KEYCODE_DEL}, {@link KeyEvent#KEYCODE_DPAD_RIGHT} and so on...

--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Solo.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Solo.java
@@ -632,7 +632,7 @@ public class Solo {
 	
 	public void goBack()
 	{
-		robotiumUtils.goBack();
+		activityUtils.goBack();
 	}
 	
 	/**
@@ -1929,21 +1929,13 @@ public class Solo {
 	}
     
     /**
-     * All inactive activities are finished.
-     */
-
-    public void finishInactiveActivities() {
-    	activityUtils.finishInactiveActivities();
-    }
-
-    /**
-     *
-     * All activities that have been active are finished.
-     *
-     */
-
-    public void finishOpenedActivities(){
-    	activityUtils.finishOpenedActivities();
-    }
+	 *
+	 * All activities that have been active are finished.
+	 *
+	 */
+	
+	public void finishOpenedActivities(){
+		activityUtils.finishOpenedActivities();
+	}
 	
 }


### PR DESCRIPTION
I would like to review my workaround for activity monitor not returning the correct activity after calling goBack() method. Basically  it defines an internal stack that is maintained using a timer to fetch the activityMonitor last activity. It also redefines goBack method to register the last finished activity and avoid adding it to the internal stack.
