### PR TITLE
Fix for Robotium Issue 211 - clickOnView does not work on some phones

### DIFF
--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Solo.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Solo.java
@@ -118,7 +118,7 @@ public class Solo {
         this.asserter = new Asserter(activityUtils, waiter);
         this.checker = new Checker(viewFetcher, waiter);
         this.robotiumUtils = new RobotiumUtils(instrumentation, sleeper);
-        this.clicker = new Clicker(viewFetcher, scroller,robotiumUtils, instrumentation, sleeper, waiter);
+        this.clicker = new Clicker(viewFetcher, scroller,robotiumUtils, instrumentation, sleeper, waiter, activityUtils);
         this.presser = new Presser(clicker, instrumentation, sleeper, waiter);
         this.textEnterer = new TextEnterer(instrumentation, clicker);
 	}


### PR DESCRIPTION
This does it's best to calculate an X and Y density multiplier.  This has been tested on a Galaxy S2, Galaxy Tab 7 Plus, Galaxy S, HTC Evo 4G and 160, 240 and 320dpi emulators
