### PR TITLE
Memory Leak Fix

### DIFF
--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/ActivityUtils.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/ActivityUtils.java
@@ -273,14 +273,17 @@ class ActivityUtils {
 	 * Finalizes the solo object.
 	 *
 	 */  
-
+        @Override
 	public void finalize() throws Throwable {
+		activitySyncTimer.cancel();
 		try {
 			// Remove the monitor added during startup
 			if (activityMonitor != null) {
 				inst.removeMonitor(activityMonitor);
+				activityMonitor = null;
 			}
 		} catch (Exception ignored) {}
+		this.activity = null;
 		super.finalize();
 	}
 	


### PR DESCRIPTION
Minor change to prevent memory leak. In some instances, ActivityUtils would keep a reference to the activity, causing a buildup in memory from multiple tests holding on to previous activities.
