### PR TITLE
Updated javadoc of params that accept regex

### DIFF
--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Solo.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Solo.java
@@ -197,7 +197,7 @@ public class Solo {
     /**
 	 * Waits for a text to be shown. Default timeout is 20 seconds. 
 	 * 
-	 * @param text the text to wait for
+	 * @param text the text to wait for, specified as a regular expression
 	 * @return {@code true} if text is shown and {@code false} if it is not shown before the timeout
 	 * 
 	 */
@@ -210,7 +210,7 @@ public class Solo {
 	 /**
 	 * Waits for a text to be shown. 
 	 * 
-	 * @param text the text to wait for
+	 * @param text the text to wait for, specified as a regular expression
 	 * @param minimumNumberOfMatches the minimum number of matches that are expected to be shown. {@code 0} means any number of matches
 	 * @param timeout the the amount of time in milliseconds to wait 
 	 * @return {@code true} if text is shown and {@code false} if it is not shown before the timeout
@@ -224,7 +224,7 @@ public class Solo {
 	 /**
 	 * Waits for a text to be shown. 
 	 * 
-	 * @param text the text to wait for
+	 * @param text the text to wait for, specified as a regular expression
 	 * @param minimumNumberOfMatches the minimum number of matches that are expected to be shown. {@code 0} means any number of matches
 	 * @param timeout the the amount of time in milliseconds to wait
 	 * @param scroll {@code true} if scrolling should be performed
@@ -239,7 +239,7 @@ public class Solo {
 	/**
 	 * Waits for a text to be shown. 
 	 * 
-	 * @param text the text to wait for
+	 * @param text the text to wait for, specified as a regular expression
 	 * @param minimumNumberOfMatches the minimum number of matches that are expected to be shown. {@code 0} means any number of matches
 	 * @param timeout the the amount of time in milliseconds to wait
 	 * @param scroll {@code true} if scrolling should be performed

--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Waiter.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Waiter.java
@@ -273,7 +273,7 @@ class Waiter {
 	/**
 	 * Waits for a text to be shown. Default timeout is 20 seconds.
 	 *
-	 * @param text the text that needs to be shown
+	 * @param text the text that needs to be shown, specified as a regular expression
 	 * @return {@code true} if text is found and {@code false} if it is not found before the timeout
 	 * 
 	 */
@@ -285,7 +285,7 @@ class Waiter {
 	/**
 	 * Waits for a text to be shown. Default timeout is 20 seconds. 
 	 * 
-	 * @param text the text that needs to be shown
+	 * @param text the text that needs to be shown, specified as a regular expression
 	 * @param expectedMinimumNumberOfMatches the minimum number of matches of text that must be shown. {@code 0} means any number of matches
 	 * @return {@code true} if text is found and {@code false} if it is not found before the timeout
 	 * 
@@ -299,7 +299,7 @@ class Waiter {
 	/**
 	 * Waits for a text to be shown.
 	 *
-	 * @param text the text that needs to be shown
+	 * @param text the text that needs to be shown, specified as a regular expression
 	 * @param expectedMinimumNumberOfMatches the minimum number of matches of text that must be shown. {@code 0} means any number of matches
 	 * @param timeout the amount of time in milliseconds to wait
 	 * @return {@code true} if text is found and {@code false} if it is not found before the timeout
@@ -314,7 +314,7 @@ class Waiter {
 	/**
 	 * Waits for a text to be shown.
 	 *
-	 * @param text the text that needs to be shown
+	 * @param text the text that needs to be shown, specified as a regular expression
 	 * @param expectedMinimumNumberOfMatches the minimum number of matches of text that must be shown. {@code 0} means any number of matches
 	 * @param timeout the amount of time in milliseconds to wait
 	 * @param scroll {@code true} if scrolling should be performed
@@ -329,7 +329,7 @@ class Waiter {
 	/**
 	 * Waits for a text to be shown.
 	 *
-	 * @param text the text that needs to be shown
+	 * @param text the text that needs to be shown, specified as a regular expression.
 	 * @param expectedMinimumNumberOfMatches the minimum number of matches of text that must be shown. {@code 0} means any number of matches
 	 * @param timeout the amount of time in milliseconds to wait
 	 * @param scroll {@code true} if scrolling should be performed


### PR DESCRIPTION
When using Robotium it can be unclear without looking at the source code that whether parameters expect plain-text or regex.
