### PR TITLE
Solo.getView(Class<T>) should return T

### DIFF
--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Solo.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Solo.java
@@ -1627,7 +1627,7 @@ public class Solo {
 	 * @return a {@link View} with a given class and index
 	 */
 
-	public <T extends View> View getView(Class<T> viewClass, int index){
+	public <T extends View> T getView(Class<T> viewClass, int index){
 		return waiter.waitForAndGetView(index, viewClass);
 	}
 	


### PR DESCRIPTION
Currently it returns a generic View.
Change is trivial because the delegate method already returns T.
