### PR TITLE
remove @ovverride for interface methods as source compat is 1.5

### DIFF
--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/RobotiumWebClient.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/RobotiumWebClient.java
@@ -44,7 +44,6 @@ class RobotiumWebClient extends WebChromeClient{
 			if(webView != null){ 
 
 				inst.runOnMainSync(new Runnable() {
-					@Override
 					public void run() {
 						webView.getSettings().setJavaScriptEnabled(true);
 						webView.setWebChromeClient(robotiumWebClient);

--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/ScreenshotTaker.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/ScreenshotTaker.java
@@ -60,7 +60,6 @@ class ScreenshotTaker {
 		activityUtils.getCurrentActivity(false).runOnUiThread(new Runnable() {
 			Bitmap  b;
 
-			@Override
 			public void run() {
 				if(view !=null){
 

--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/ViewLocationComparator.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/ViewLocationComparator.java
@@ -27,7 +27,6 @@ class ViewLocationComparator implements Comparator<View> {
 		this.axis2 = yAxisFirst ? 0 : 1;
 	}
 
-	@Override
 	public int compare(View lhs, View rhs) {
 		lhs.getLocationOnScreen(a);
 		rhs.getLocationOnScreen(b);

--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/WebUtils.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/WebUtils.java
@@ -214,7 +214,6 @@ class WebUtils {
 		final String javaScript = prepareForStartOfJavascriptExecution();
 
 		activityUtils.getCurrentActivity(false).runOnUiThread(new Runnable() {
-			@Override
 			public void run() {
 				if(webView != null){
 					webView.loadUrl("javascript:" + javaScript + function);


### PR DESCRIPTION
pom.xml has javac compiler level set to 1.5 and that does not support
@override for interface methods. Build would fail if somebody actually
ran it with a 1.5 java compiler. See
http://stackoverflow.com/questions/1193184/does-maven-really-honor-the-source-tag-in-the-compiler-plugin
why this built before even though it should have failed.
