### PR TITLE
Added override to waitForActivity which takes Class<? extends Activity> parameter

### DIFF
--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Solo.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Solo.java
@@ -2023,8 +2023,7 @@ public class Solo {
 	 *
 	 */
 	
-	public void goBackToActivity(String name)
-	{
+	public void goBackToActivity(String name) {
 		activityUtils.goBackToActivity(name);
 	}
 	
@@ -2053,6 +2052,32 @@ public class Solo {
 	{
 		return waiter.waitForActivity(name, timeout);
 	}
+
+    /**
+     * Waits for the given Activity. Default timeout is 20 seconds.
+     *
+     * @param clazz the class of the {@code Activity} to wait for e.g. {@code "MyActivity"}
+     * @return {@code true} if {@code Activity} appears before the timeout and {@code false} if it does not
+     *
+     */
+
+    public boolean waitForActivity(Class<? extends Activity> clazz){
+        return waiter.waitForActivity(clazz, TIMEOUT);
+    }
+
+    /**
+     * Waits for the given Activity.
+     *
+     * @param clazz the class of the {@code Activity} to wait for e.g. {@code "MyActivity"}
+     * @param timeout the amount of time in milliseconds to wait
+     * @return {@code true} if {@link Activity} appears before the timeout and {@code false} if it does not
+     *
+     */
+
+    public boolean waitForActivity(Class<? extends Activity> clazz, int timeout)
+    {
+        return waiter.waitForActivity(clazz, timeout);
+    }
 	
 	
 	/**

--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Waiter.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/Waiter.java
@@ -85,6 +85,40 @@ class Waiter {
 		return false;
 	}
 
+    /**
+     * Waits for the given {@link Activity}.
+     *
+     * @param clazz the class of the {@code Activity} to wait for e.g. {@code "MyActivity"}
+     * @return {@code true} if {@code Activity} appears before the timeout and {@code false} if it does not
+     *
+     */
+
+    public boolean waitForActivity(Class<? extends Activity> clazz){
+        return waitForActivity(clazz, SMALLTIMEOUT);
+    }
+
+    /**
+     * Waits for the given {@link Activity}.
+     *
+     * @param clazz the class of the {@code Activity} to wait for e.g. {@code "MyActivity"}
+     * @param timeout the amount of time in milliseconds to wait
+     * @return {@code true} if {@code Activity} appears before the timeout and {@code false} if it does not
+     *
+     */
+
+    public boolean waitForActivity(Class<? extends Activity> clazz, int timeout){
+        final long endTime = SystemClock.uptimeMillis() + timeout;
+        Activity currentActivity = activityUtils.getCurrentActivity(false);
+
+        while(SystemClock.uptimeMillis() < endTime){
+            if(currentActivity != null && currentActivity.getClass().equals(clazz))
+                return true;
+
+            currentActivity = activityUtils.getCurrentActivity();
+        }
+        return false;
+    }
+
 	/**
 	 * Waits for a view to be shown.
 	 * 
@@ -144,9 +178,11 @@ class Waiter {
 		return false;
 	}
 
-	/**
+
+
+    /**
 	 * Waits for two views to be shown.
-	 * 
+	 *
 	 * @param viewClass the first {@code View} class to wait for 
 	 * @param viewClass2 the second {@code View} class to wait for
 	 * @return {@code true} if any of the views are shown and {@code false} if none of the views are shown before the timeout


### PR DESCRIPTION
as assertCurrentActivity, now waitForActivity can also take Class<? extends Activity> parameter.
Allowed me to find compile-time errors (e.g., typos, deleted classes, etc)
