### PR TITLE
Added a null check in GLRenderWrapper.

### DIFF
--- a/robotium-solo/src/main/java/com/jayway/android/robotium/solo/GLRenderWrapper.java
+++ b/robotium-solo/src/main/java/com/jayway/android/robotium/solo/GLRenderWrapper.java
@@ -47,8 +47,14 @@ class GLRenderWrapper implements Renderer {
 		this.width = view.getWidth();
 		this.height = view.getHeight();
 		
-		this.glVersion = new Reflect(view).field("mEGLContextClientVersion")
-				.out(Integer.class).intValue();
+		Integer out = new Reflect(view).field("mEGLContextClientVersion")
+				.out(Integer.class);
+		if ( out != null ) {
+			this.glVersion = out.intValue();
+		} else {
+			this.glVersion = -1;
+			this.takeScreenshot = false;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This should make sure no null pointer exception is thrown. This property might be moved in other versions of android and this need to be fixed.
