### PR TITLE
fix: Exception doesn't catch NoSuchMethodError, Throwable does

### DIFF
--- a/robotium-solo/src/main/java/com/robotium/solo/Waiter.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/Waiter.java
@@ -715,7 +715,7 @@ class Waiter {
 				return activityUtils.getCurrentActivity().getFragmentManager().findFragmentById(id);
 			else
 				return activityUtils.getCurrentActivity().getFragmentManager().findFragmentByTag(tag);
-		}catch (Exception ignored) {}
+		}catch (Throwable ignored) {}
 
 		return null;
 	}


### PR DESCRIPTION
I am getting NoSuchMethodError when using waitForFragmentByTag() on Gingerbread:

```
java.lang.NoSuchMethodError: android.app.Activity.getFragmentManager
at com.robotium.solo.Waiter.getFragment(Waiter.java:717)
at com.robotium.solo.Waiter.waitForFragment(Waiter.java:563)
at com.robotium.solo.Solo.waitForFragmentByTag(Solo.java:2401)
[...]
```

Partial reverse of https://github.com/RobotiumTech/robotium/commit/5398dc4e8e5b646f22f7f4aca700025dfefeb749. Exception is not a superclass of NoSuchMethodError, hence this error is not caught. Throwable is a superclass of NoSuchMethodError and catches everything.
