### PR TITLE
Add support for input events using any MotionEvent.TOOL_TYPE

### DIFF
--- a/robotium-solo/src/main/java/com/robotium/solo/Illustration.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/Illustration.java
@@ -3,10 +3,16 @@ package com.robotium.solo;
 import java.util.ArrayList;
 import android.view.MotionEvent;
 
+/**
+ * A class used to build Illustrations for an Illustrator.
+ * Compatible with specific MotionEvent.TOOL_TYPEs
+ *
+ * @author Jake Kuli, 3kajjak3@gmail.com
+ */
 public class Illustration {
 
-  private int toolType = MotionEvent.TOOL_TYPE_STYLUS;
-  private ArrayList<PressurePoint> points = new ArrayList<PressurePoint>();
+  private final int toolType;
+  private final ArrayList<PressurePoint> points;
 
   private Illustration(Builder builder) {
       this.toolType = builder.builderToolType;
@@ -15,9 +21,14 @@ public class Illustration {
 
   public static class Builder {
 
-      private int builderToolType;
+      private int builderToolType = MotionEvent.TOOL_TYPE_FINGER;
       private ArrayList<PressurePoint> builderPoints = new ArrayList<PressurePoint>();
 
+      /**
+        * Sets the tool type to use when illustrating.
+        * By default this is set to MotionEvent.TOOL_TYPE_FINGER
+        * @param toolType a static int from MotionEvent's TOOL_TYPEs
+        */
       public Builder setToolType(int toolType) {
           builderToolType = toolType;
           return this;
@@ -33,13 +44,11 @@ public class Illustration {
       }
   }
 
-  public ArrayList<PressurePoint> getPoints()
-  {
+  public ArrayList<PressurePoint> getPoints() {
     return points;
   }
 
-  public int getToolType()
-  {
+  public int getToolType() {
     return toolType;
   }
 }

--- a/robotium-solo/src/main/java/com/robotium/solo/Illustration.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/Illustration.java
@@ -1,0 +1,45 @@
+package com.robotium.solo;
+
+import java.util.ArrayList;
+import android.view.MotionEvent;
+
+public class Illustration {
+
+  private int toolType = MotionEvent.TOOL_TYPE_STYLUS;
+  private ArrayList<PressurePoint> points = new ArrayList<PressurePoint>();
+
+  private Illustration(Builder builder) {
+      this.toolType = builder.builderToolType;
+      this.points = builder.builderPoints;
+  }
+
+  public static class Builder {
+
+      private int builderToolType;
+      private ArrayList<PressurePoint> builderPoints = new ArrayList<PressurePoint>();
+
+      public Builder setToolType(int toolType) {
+          builderToolType = toolType;
+          return this;
+      }
+
+      public Builder addPoint(float x, float y, float pressure) {
+          builderPoints.add(new PressurePoint(x, y, pressure));
+          return this;
+      }
+
+      public Illustration build() {
+          return new Illustration(this);
+      }
+  }
+
+  public ArrayList<PressurePoint> getPoints()
+  {
+    return points;
+  }
+
+  public int getToolType()
+  {
+    return toolType;
+  }
+}

--- a/robotium-solo/src/main/java/com/robotium/solo/Illustration.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/Illustration.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import android.view.MotionEvent;
 
 /**
- * A class used to build Illustrations for an Illustrator.
+ * A class used to pass Illustrations to an Illustrator.
  * Compatible with specific MotionEvent.TOOL_TYPEs
  *
  * @author Jake Kuli, 3kajjak3@gmail.com
@@ -19,6 +19,9 @@ public class Illustration {
       this.points = builder.builderPoints;
   }
 
+  /**
+   * Builder class to build illustrations
+   */
   public static class Builder {
 
       private int builderToolType = MotionEvent.TOOL_TYPE_FINGER;
@@ -27,7 +30,7 @@ public class Illustration {
       /**
         * Sets the tool type to use when illustrating.
         * By default this is set to MotionEvent.TOOL_TYPE_FINGER
-        * @param toolType a static int from MotionEvent's TOOL_TYPEs
+        * @param toolType an int from MotionEvent's static int TOOL_TYPEs
         */
       public Builder setToolType(int toolType) {
           builderToolType = toolType;

--- a/robotium-solo/src/main/java/com/robotium/solo/Illustrator.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/Illustrator.java
@@ -23,7 +23,7 @@ class Illustrator {
 
     public void illustrate(Illustration illustration) {
         if (illustration == null || illustration.getPoints().isEmpty()) {
-            throw new IllegalArgumentException("Illustration requires at least one point.");
+            throw new IllegalArgumentException("Illustration must not be null and requires at least one point.");
         }
         MotionEvent event;
         int currentAction;
@@ -39,9 +39,10 @@ class Illustrator {
         coords[0] = coord;
         ArrayList<PressurePoint> points = illustration.getPoints();
         for (int i = 0; i < points.size(); i++) {
-            coord.x = points.get(i).x;
-            coord.y = points.get(i).y;
-            coord.pressure = points.get(i).pressure;
+            PressurePoint currentPoint = points.get(i);
+            coord.x = currentPoint.x;
+            coord.y = currentPoint.y;
+            coord.pressure = currentPoint.pressure;
             coord.size = 1;
             if (i == 0) {
                 currentAction = MotionEvent.ACTION_DOWN;
@@ -49,7 +50,7 @@ class Illustrator {
             else {
                 currentAction = MotionEvent.ACTION_MOVE;
             }
-
+            eventTime = SystemClock.uptimeMillis();
             event = MotionEvent.obtain(downTime,
                 eventTime,
                 currentAction,
@@ -61,14 +62,17 @@ class Illustrator {
                 0);
             try {
 			    inst.sendPointerSync(event);
-		    } catch (SecurityException ignored) {}
+		    }
+            catch (SecurityException ignored) {}
         }
         currentAction = MotionEvent.ACTION_UP;
-        coords[0] = new PointerCoords();
-        coords[0].x = points.get(points.size() - 1).x;
-        coords[0].y = points.get(points.size() - 1).y;
-        coords[0].pressure = points.get(points.size() - 1).pressure;
-        coords[0].size = 1;
+        coords[0] = coord;
+        PressurePoint currentPoint = points.get(points.size() - 1);
+        coord.x = currentPoint.x;
+        coord.y = currentPoint.y;
+        coord.pressure = currentPoint.pressure;
+        coord.size = 1;
+        eventTime = SystemClock.uptimeMillis();
         event = MotionEvent.obtain(downTime,
             eventTime,
             currentAction,
@@ -80,6 +84,7 @@ class Illustrator {
             0);
         try {
 			inst.sendPointerSync(event);
-		} catch (SecurityException ignored) {}
+		}
+        catch (SecurityException ignored) {}
     }
 }

--- a/robotium-solo/src/main/java/com/robotium/solo/Illustrator.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/Illustrator.java
@@ -1,0 +1,77 @@
+package com.robotium.solo;
+
+import java.util.ArrayList;
+import android.view.MotionEvent;
+import android.view.MotionEvent.PointerProperties;
+import android.view.MotionEvent.PointerCoords;
+import android.view.InputDevice;
+import android.app.Instrumentation;
+import android.os.SystemClock;
+
+class Illustrator {
+
+    private Instrumentation inst;
+
+    public Illustrator(Instrumentation inst) {
+        this.inst = inst;
+    }
+
+    public void illustrate(Illustration illustration) {
+        MotionEvent event;
+        int currentAction;
+        PointerCoords[] coords = new PointerCoords[1];
+        PointerProperties[] properties = new PointerProperties[1];
+        PointerProperties prop = new PointerProperties();
+        prop.id = 0;
+        prop.toolType = illustration.getToolType();
+        properties[0] = prop;
+        ArrayList<PressurePoint> points = illustration.getPoints();
+        if (points.size() > 0) {
+            for (int i = 0; i < points.size(); i++) {
+                coords[0] = new PointerCoords();
+                coords[0].x = points.get(i).x;
+                coords[0].y = points.get(i).y;
+                coords[0].pressure = points.get(i).pressure;
+                coords[0].size = 1;
+
+                long downTime = SystemClock.uptimeMillis();
+                long eventTime = SystemClock.uptimeMillis();
+
+                if (i == 0) currentAction = MotionEvent.ACTION_DOWN;
+                else currentAction = MotionEvent.ACTION_MOVE;
+
+                event = MotionEvent.obtain(downTime,
+                    eventTime,
+                    currentAction,
+                    1,
+                    properties,
+                    coords,
+                    0, 0, 1, 1, 0, 0,
+                    InputDevice.SOURCE_TOUCHSCREEN,
+                    0);
+                inst.sendPointerSync(event);
+            }
+            currentAction = MotionEvent.ACTION_UP;
+            coords[0] = new PointerCoords();
+            coords[0].x = points.get(points.size() - 1).x;
+            coords[0].y = points.get(points.size() - 1).y;
+            coords[0].pressure = points.get(points.size() - 1).pressure;
+            coords[0].size = 1;
+            long downTime = SystemClock.uptimeMillis();
+            long eventTime = SystemClock.uptimeMillis();
+            event = MotionEvent.obtain(downTime,
+                eventTime,
+                currentAction,
+                1,
+                properties,
+                coords,
+                0, 0, 1, 1, 0, 0,
+                InputDevice.SOURCE_TOUCHSCREEN,
+                0);
+            inst.sendPointerSync(event);
+        }
+        else {
+            throw new RuntimeException("Illustration requires at least one point.");
+        }
+    }
+}

--- a/robotium-solo/src/main/java/com/robotium/solo/PressurePoint.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/PressurePoint.java
@@ -1,11 +1,16 @@
 package com.robotium.solo;
 
+/**
+ * A class to describe points and respective pressures in an Illustration
+ *
+ * @author Jake Kuli, 3kajjak3@gmail.com
+ */
 class PressurePoint {
     public final float x;
     public final float y;
     public final float pressure;
 
-    public PressurePoint(float x, float y, float pressure){
+    public PressurePoint(float x, float y, float pressure) {
         this.x = x;
         this.y = y;
         this.pressure = pressure;

--- a/robotium-solo/src/main/java/com/robotium/solo/PressurePoint.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/PressurePoint.java
@@ -1,0 +1,13 @@
+package com.robotium.solo;
+
+class PressurePoint {
+    public final float x;
+    public final float y;
+    public final float pressure;
+
+    public PressurePoint(float x, float y, float pressure){
+        this.x = x;
+        this.y = y;
+        this.pressure = pressure;
+    }
+}

--- a/robotium-solo/src/main/java/com/robotium/solo/Solo.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/Solo.java
@@ -33,12 +33,12 @@ import android.widget.ToggleButton;
 import android.app.Instrumentation.ActivityMonitor;
 
 /**
- * Main class for development of Robotium tests.  
- * Robotium has full support for Views, WebViews, Activities, Dialogs, Menus and Context Menus. 
+ * Main class for development of Robotium tests.
+ * Robotium has full support for Views, WebViews, Activities, Dialogs, Menus and Context Menus.
  * <br>
- * Robotium can be used in conjunction with Android test classes like 
- * ActivityInstrumentationTestCase2 and SingleLaunchActivityTestCase. 
- * 
+ * Robotium can be used in conjunction with Android test classes like
+ * ActivityInstrumentationTestCase2 and SingleLaunchActivityTestCase.
+ *
  *
  *
  *
@@ -61,6 +61,7 @@ public class Solo {
 	protected final Sleeper sleeper;
 	protected final Swiper swiper;
 	protected final Tapper tapper;
+	protected final Illustrator illustrator;
 	protected final Waiter waiter;
 	protected final Setter setter;
 	protected final Getter getter;
@@ -93,37 +94,37 @@ public class Solo {
 	 */
 
 	public Solo(Instrumentation instrumentation, Activity activity) {
-		this(new Config(), instrumentation, activity);	
+		this(new Config(), instrumentation, activity);
 	}
 
 	/**
 	 * Constructor that takes the Instrumentation and Config objects.
 	 *
 	 * @param instrumentation the {@link Instrumentation} instance
-	 * @param config the {@link Config} instance 
+	 * @param config the {@link Config} instance
 	 */
 
 	public Solo(Instrumentation instrumentation, Config config) {
-		this(config, instrumentation, null);	
+		this(config, instrumentation, null);
 	}
-	
+
 	/**
 	 * Constructor that takes the Instrumentation, Config and Activity objects.
 	 *
 	 * @param instrumentation the {@link Instrumentation} instance
-	 * @param config the {@link Config} instance 
+	 * @param config the {@link Config} instance
 	 * @param activity the start {@link Activity} or {@code null}
 	 * if no Activity is specified
 	 */
 
 	public Solo(Instrumentation instrumentation, Config config, Activity activity) {
-		this(config, instrumentation, activity);	
+		this(config, instrumentation, activity);
 	}
 
 	/**
 	 * Private constructor.
-	 * 
-	 * @param config the {@link Config} instance. If {@code null} one will be created. 
+	 *
+	 * @param config the {@link Config} instance. If {@code null} one will be created.
 	 * @param instrumentation the {@link Instrumentation} instance
 	 * @param activity the start {@link Activity} or {@code null}
 	 * if no Activity is specified
@@ -150,6 +151,7 @@ public class Solo {
 		this.zoomer = new Zoomer(instrumentation);
 		this.swiper = new Swiper(instrumentation);
 		this.tapper =  new Tapper(instrumentation);
+		this.illustrator = new Illustrator(instrumentation);
 		this.rotator = new Rotator(instrumentation);
 		this.presser = new Presser(viewFetcher, clicker, instrumentation, sleeper, waiter, dialogUtils);
 		this.textEnterer = new TextEnterer(instrumentation, clicker, dialogUtils);
@@ -171,7 +173,7 @@ public class Solo {
 	 *	getActivity();
 	 * }
 	 * </pre>
-	 * 
+	 *
 	 * @author Renas Reda, renas.reda@robotium.com
 	 */
 
@@ -193,34 +195,34 @@ public class Solo {
 		public String screenshotSavePath = Environment.getExternalStorageDirectory() + "/Robotium-Screenshots/";
 
 		/**
-		 * The screenshot file type, JPEG or PNG. Use ScreenshotFileType.JPEG or ScreenshotFileType.PNG. Default file type is JPEG. 
+		 * The screenshot file type, JPEG or PNG. Use ScreenshotFileType.JPEG or ScreenshotFileType.PNG. Default file type is JPEG.
 		 */
 		public ScreenshotFileType screenshotFileType = ScreenshotFileType.JPEG;
 
 		/**
 		 * Set to true if the get, is, set, enter, type and click methods should scroll. Default value is true.
 		 */
-		public boolean shouldScroll = true;	
+		public boolean shouldScroll = true;
 
 		/**
-		 * Set to true if JavaScript should be used to click WebElements. Default value is false. 
+		 * Set to true if JavaScript should be used to click WebElements. Default value is false.
 		 */
 		public boolean useJavaScriptToClickWebElements = false;
 
 		/**
 		 * The screenshot file type, JPEG or PNG.
-		 * 
+		 *
 		 * @author Renas Reda, renas.reda@robotium.com
 		 *
 		 */
 		public enum ScreenshotFileType {
 			JPEG, PNG
 		}
-		
+
 		/**
 		 *  Set to true if Activity tracking should be enabled. Default value is true.
 		 */
-		
+
 		public boolean trackActivities = true;
 	}
 
@@ -236,7 +238,7 @@ public class Solo {
 
 	/**
 	 * Returns the ActivityMonitor used by Robotium.
-	 * 
+	 *
 	 * @return the ActivityMonitor used by Robotium
 	 */
 
@@ -246,16 +248,16 @@ public class Solo {
 
 	/**
 	 * Returns the Config used by Robotium.
-	 * 
+	 *
 	 * @return the Config used by Robotium
 	 */
 
 	public Config getConfig(){
 		return config;
 	}
-	
+
 	/**
-	 * Returns an ArrayList of all the View objects located in the focused 
+	 * Returns an ArrayList of all the View objects located in the focused
 	 * Activity or Dialog.
 	 *
 	 * @return an {@code ArrayList} of the {@link View} objects located in the focused window
@@ -291,7 +293,7 @@ public class Solo {
 	 *
 	 * @param view the {@link View} whose top parent is requested
 	 * @return the top parent {@link View}
-	 */	
+	 */
 
 	public View getTopParent(View view) {
 		View topParent = viewFetcher.getTopParent(view);
@@ -299,8 +301,8 @@ public class Solo {
 	}
 
 	/**
-	 * Waits for the specified text to appear. Default timeout is 20 seconds. 
-	 * 
+	 * Waits for the specified text to appear. Default timeout is 20 seconds.
+	 *
 	 * @param text the text to wait for, specified as a regular expression
 	 * @return {@code true} if text is displayed and {@code false} if it is not displayed before the timeout
 	 */
@@ -310,11 +312,11 @@ public class Solo {
 	}
 
 	/**
-	 * Waits for the specified text to appear. 
-	 * 
+	 * Waits for the specified text to appear.
+	 *
 	 * @param text the text to wait for, specified as a regular expression
 	 * @param minimumNumberOfMatches the minimum number of matches that are expected to be found. {@code 0} means any number of matches
-	 * @param timeout the the amount of time in milliseconds to wait 
+	 * @param timeout the the amount of time in milliseconds to wait
 	 * @return {@code true} if text is displayed and {@code false} if it is not displayed before the timeout
 	 */
 
@@ -323,8 +325,8 @@ public class Solo {
 	}
 
 	/**
-	 * Waits for the specified text to appear. 
-	 * 
+	 * Waits for the specified text to appear.
+	 *
 	 * @param text the text to wait for, specified as a regular expression
 	 * @param minimumNumberOfMatches the minimum number of matches that are expected to be found. {@code 0} means any number of matches
 	 * @param timeout the the amount of time in milliseconds to wait
@@ -337,8 +339,8 @@ public class Solo {
 	}
 
 	/**
-	 * Waits for the specified text to appear. 
-	 * 
+	 * Waits for the specified text to appear.
+	 *
 	 * @param text the text to wait for, specified as a regular expression
 	 * @param minimumNumberOfMatches the minimum number of matches that are expected to be found. {@code 0} means any number of matches
 	 * @param timeout the the amount of time in milliseconds to wait
@@ -352,8 +354,8 @@ public class Solo {
 	}
 
 	/**
-	 * Waits for a View matching the specified resource id. Default timeout is 20 seconds. 
-	 * 
+	 * Waits for a View matching the specified resource id. Default timeout is 20 seconds.
+	 *
 	 * @param id the R.id of the {@link View} to wait for
 	 * @return {@code true} if the {@link View} is displayed and {@code false} if it is not displayed before the timeout
 	 */
@@ -363,8 +365,8 @@ public class Solo {
 	}
 
 	/**
-	 * Waits for a View matching the specified resource id. 
-	 * 
+	 * Waits for a View matching the specified resource id.
+	 *
 	 * @param id the R.id of the {@link View} to wait for
 	 * @param minimumNumberOfMatches the minimum number of matches that are expected to be found. {@code 0} means any number of matches
 	 * @param timeout the amount of time in milliseconds to wait
@@ -376,8 +378,8 @@ public class Solo {
 	}
 
 	/**
-	 * Waits for a View matching the specified resource id. 
-	 * 
+	 * Waits for a View matching the specified resource id.
+	 *
 	 * @param id the R.id of the {@link View} to wait for
 	 * @param minimumNumberOfMatches the minimum number of matches that are expected to be found. {@code 0} means any number of matches
 	 * @param timeout the amount of time in milliseconds to wait
@@ -439,8 +441,8 @@ public class Solo {
 	}
 
 	/**
-	 * Waits for a View matching the specified class. Default timeout is 20 seconds. 
-	 * 
+	 * Waits for a View matching the specified class. Default timeout is 20 seconds.
+	 *
 	 * @param viewClass the {@link View} class to wait for
 	 * @return {@code true} if the {@link View} is displayed and {@code false} if it is not displayed before the timeout
 	 */
@@ -451,8 +453,8 @@ public class Solo {
 	}
 
 	/**
-	 * Waits for the specified View. Default timeout is 20 seconds. 
-	 * 
+	 * Waits for the specified View. Default timeout is 20 seconds.
+	 *
 	 * @param view the {@link View} object to wait for
 	 * @return {@code true} if the {@link View} is displayed and {@code false} if it is not displayed before the timeout
 	 */
@@ -462,8 +464,8 @@ public class Solo {
 	}
 
 	/**
-	 * Waits for the specified View. 
-	 * 
+	 * Waits for the specified View.
+	 *
 	 * @param view the {@link View} object to wait for
 	 * @param timeout the amount of time in milliseconds to wait
 	 * @param scroll {@code true} if scrolling should be performed
@@ -476,18 +478,18 @@ public class Solo {
 		if(!scroll){
 			checkIsShown = true;
 		}
-		
+
 		View viewToWaitFor = waiter.waitForView(view, timeout, scroll, checkIsShown);
-		
+
 		if(viewToWaitFor != null)
 			return true;
-		
+
 		return false;
 	}
 
 	/**
 	 * Waits for a View matching the specified class.
-	 * 
+	 *
 	 * @param viewClass the {@link View} class to wait for
 	 * @param minimumNumberOfMatches the minimum number of matches that are expected to be found. {@code 0} means any number of matches
 	 * @param timeout the amount of time in milliseconds to wait
@@ -505,7 +507,7 @@ public class Solo {
 
 	/**
 	 * Waits for a View matching the specified class.
-	 * 
+	 *
 	 * @param viewClass the {@link View} class to wait for
 	 * @param minimumNumberOfMatches the minimum number of matches that are expected to be found. {@code 0} means any number of matches
 	 * @param timeout the amount of time in milliseconds to wait
@@ -523,8 +525,8 @@ public class Solo {
 	}
 
 	/**
-	 * Waits for a WebElement matching the specified By object. Default timeout is 20 seconds. 
-	 * 
+	 * Waits for a WebElement matching the specified By object. Default timeout is 20 seconds.
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
 	 * @return {@code true} if the {@link WebElement} is displayed and {@code false} if it is not displayed before the timeout
 	 */
@@ -535,9 +537,9 @@ public class Solo {
 
 	/**
 	 * Waits for a WebElement matching the specified By object.
-	 * 
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
-	 * @param timeout the the amount of time in milliseconds to wait 
+	 * @param timeout the the amount of time in milliseconds to wait
 	 * @param scroll {@code true} if scrolling should be performed
 	 * @return {@code true} if the {@link WebElement} is displayed and {@code false} if it is not displayed before the timeout
 	 */
@@ -548,10 +550,10 @@ public class Solo {
 
 	/**
 	 * Waits for a WebElement matching the specified By object.
-	 * 
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
 	 * @param minimumNumberOfMatches the minimum number of matches that are expected to be found. {@code 0} means any number of matches
-	 * @param timeout the the amount of time in milliseconds to wait 
+	 * @param timeout the the amount of time in milliseconds to wait
 	 * @param scroll {@code true} if scrolling should be performed
 	 * @return {@code true} if the {@link WebElement} is displayed and {@code false} if it is not displayed before the timeout
 	 */
@@ -562,7 +564,7 @@ public class Solo {
 
 	/**
 	 * Waits for a condition to be satisfied.
-	 * 
+	 *
 	 * @param condition the condition to wait for
 	 * @param timeout the amount of time in milliseconds to wait
 	 * @return {@code true} if condition is satisfied and {@code false} if it is not satisfied before the timeout
@@ -586,7 +588,7 @@ public class Solo {
 
 	/**
 	 * Searches for a Button displaying the specified text and returns {@code true} if at least one Button
-	 * is found. Will automatically scroll when needed. 
+	 * is found. Will automatically scroll when needed.
 	 *
 	 * @param text the text to search for. The parameter will be interpreted as a regular expression
 	 * @return {@code true} if a {@link Button} displaying the specified text is found and {@code false} if it is not found
@@ -598,7 +600,7 @@ public class Solo {
 
 	/**
 	 * Searches for a Button displaying the specified text and returns {@code true} if at least one Button
-	 * is found. Will automatically scroll when needed. 
+	 * is found. Will automatically scroll when needed.
 	 *
 	 * @param text the text to search for. The parameter will be interpreted as a regular expression
 	 * @param onlyVisible {@code true} if only {@link Button} visible on the screen should be searched
@@ -611,7 +613,7 @@ public class Solo {
 
 	/**
 	 * Searches for a ToggleButton displaying the specified text and returns {@code true} if at least one ToggleButton
-	 * is found. Will automatically scroll when needed. 
+	 * is found. Will automatically scroll when needed.
 	 *
 	 * @param text the text to search for. The parameter will be interpreted as a regular expression
 	 * @return {@code true} if a {@link ToggleButton} displaying the specified text is found and {@code false} if it is not found
@@ -624,7 +626,7 @@ public class Solo {
 	/**
 	 * Searches for a Button displaying the specified text and returns {@code true} if the
 	 * searched Button is found a specified number of times. Will automatically scroll when needed.
-	 * 
+	 *
 	 * @param text the text to search for. The parameter will be interpreted as a regular expression
 	 * @param minimumNumberOfMatches the minimum number of matches expected to be found. {@code 0} matches means that one or more
 	 * matches are expected to be found
@@ -639,13 +641,13 @@ public class Solo {
 	/**
 	 * Searches for a Button displaying the specified text and returns {@code true} if the
 	 * searched Button is found a specified number of times. Will automatically scroll when needed.
-	 * 
+	 *
 	 * @param text the text to search for. The parameter will be interpreted as a regular expression
 	 * @param minimumNumberOfMatches the minimum number of matches expected to be found. {@code 0} matches means that one or more
 	 * matches are expected to be found
 	 * @param onlyVisible {@code true} if only {@link Button} visible on the screen should be searched
 	 * @return {@code true} if a {@link Button} displaying the specified text is found a specified number of times and {@code false}
-	 * if it is not found 
+	 * if it is not found
 	 */
 
 	public boolean searchButton(String text, int minimumNumberOfMatches, boolean onlyVisible) {
@@ -655,12 +657,12 @@ public class Solo {
 	/**
 	 * Searches for a ToggleButton displaying the specified text and returns {@code true} if the
 	 * searched ToggleButton is found a specified number of times. Will automatically scroll when needed.
-	 * 
+	 *
 	 * @param text the text to search for. The parameter will be interpreted as a regular expression
 	 * @param minimumNumberOfMatches the minimum number of matches expected to be found. {@code 0} matches means that one or more
 	 * matches are expected to be found
 	 * @return {@code true} if a {@link ToggleButton} displaying the specified text is found a specified number of times and {@code false}
-	 * if it is not found 
+	 * if it is not found
 	 */
 
 	public boolean searchToggleButton(String text, int minimumNumberOfMatches) {
@@ -669,7 +671,7 @@ public class Solo {
 
 	/**
 	 * Searches for the specified text and returns {@code true} if at least one item
-	 * is found displaying the expected text. Will automatically scroll when needed. 
+	 * is found displaying the expected text. Will automatically scroll when needed.
 	 *
 	 * @param text the text to search for. The parameter will be interpreted as a regular expression
 	 * @return {@code true} if the search string is found and {@code false} if it is not found
@@ -681,7 +683,7 @@ public class Solo {
 
 	/**
 	 * Searches for the specified text and returns {@code true} if at least one item
-	 * is found displaying the expected text. Will automatically scroll when needed. 
+	 * is found displaying the expected text. Will automatically scroll when needed.
 	 *
 	 * @param text the text to search for. The parameter will be interpreted as a regular expression
 	 * @param onlyVisible {@code true} if only texts visible on the screen should be searched
@@ -694,13 +696,13 @@ public class Solo {
 
 	/**
 	 * Searches for the specified text and returns {@code true} if the searched text is found a specified
-	 * number of times. Will automatically scroll when needed. 
-	 * 
+	 * number of times. Will automatically scroll when needed.
+	 *
 	 * @param text the text to search for. The parameter will be interpreted as a regular expression
 	 * @param minimumNumberOfMatches the minimum number of matches expected to be found. {@code 0} matches means that one or more
 	 * matches are expected to be found
 	 * @return {@code true} if text is found a specified number of times and {@code false} if the text
-	 * is not found 
+	 * is not found
 	 */
 
 	public boolean searchText(String text, int minimumNumberOfMatches) {
@@ -710,13 +712,13 @@ public class Solo {
 	/**
 	 * Searches for the specified text and returns {@code true} if the searched text is found a specified
 	 * number of times.
-	 * 
+	 *
 	 * @param text the text to search for. The parameter will be interpreted as a regular expression.
 	 * @param minimumNumberOfMatches the minimum number of matches expected to be found. {@code 0} matches means that one or more
 	 * matches are expected to be found
 	 * @param scroll {@code true} if scrolling should be performed
 	 * @return {@code true} if text is found a specified number of times and {@code false} if the text
-	 * is not found 
+	 * is not found
 	 */
 
 	public boolean searchText(String text, int minimumNumberOfMatches, boolean scroll) {
@@ -726,14 +728,14 @@ public class Solo {
 	/**
 	 * Searches for the specified text and returns {@code true} if the searched text is found a specified
 	 * number of times.
-	 * 
+	 *
 	 * @param text the text to search for. The parameter will be interpreted as a regular expression.
 	 * @param minimumNumberOfMatches the minimum number of matches expected to be found. {@code 0} matches means that one or more
 	 * matches are expected to be found
 	 * @param scroll {@code true} if scrolling should be performed
 	 * @param onlyVisible {@code true} if only texts visible on the screen should be searched
 	 * @return {@code true} if text is found a specified number of times and {@code false} if the text
-	 * is not found 
+	 * is not found
 	 */
 
 	public boolean searchText(String text, int minimumNumberOfMatches, boolean scroll, boolean onlyVisible) {
@@ -742,7 +744,7 @@ public class Solo {
 
 	/**
 	 * Sets the Orientation (Landscape/Portrait) for the current Activity.
-	 * 
+	 *
 	 * @param orientation the orientation to set. <code>Solo.</code>{@link #LANDSCAPE} for landscape or
 	 * <code>Solo.</code>{@link #PORTRAIT} for portrait.
 	 */
@@ -764,19 +766,19 @@ public class Solo {
 
 	/**
 	 * Asserts that the Activity matching the specified name is active.
-	 * 
+	 *
 	 * @param message the message to display if the assert fails
 	 * @param name the name of the {@link Activity} that is expected to be active. Example is: {@code "MyActivity"}
 	 */
 
 	public void assertCurrentActivity(String message, String name)
-	{	
+	{
 		asserter.assertCurrentActivity(message, name);
 	}
 
 	/**
 	 * Asserts that the Activity matching the specified class is active.
-	 * 
+	 *
 	 * @param message the message to display if the assert fails
 	 * @param activityClass the class of the Activity that is expected to be active. Example is: {@code MyActivity.class}
 	 */
@@ -791,7 +793,7 @@ public class Solo {
 	/**
 	 * Asserts that the Activity matching the specified name is active, with the possibility to
 	 * verify that the expected Activity is a new instance of the Activity.
-	 * 
+	 *
 	 * @param message the message to display if the assert fails
 	 * @param name the name of the Activity that is expected to be active. Example is: {@code "MyActivity"}
 	 * @param isNewInstance {@code true} if the expected {@link Activity} is a new instance of the {@link Activity}
@@ -805,7 +807,7 @@ public class Solo {
 	/**
 	 * Asserts that the Activity matching the specified class is active, with the possibility to
 	 * verify that the expected Activity is a new instance of the Activity.
-	 * 
+	 *
 	 * @param message the message to display if the assert fails
 	 * @param activityClass the class of the Activity that is expected to be active. Example is: {@code MyActivity.class}
 	 * @param isNewInstance {@code true} if the expected {@link Activity} is a new instance of the {@link Activity}
@@ -815,7 +817,7 @@ public class Solo {
 	public void assertCurrentActivity(String message, @SuppressWarnings("rawtypes") Class activityClass,
 			boolean isNewInstance) {
 		asserter.assertCurrentActivity(message, activityClass, isNewInstance);
-	}	
+	}
 
 	/**
 	 * Asserts that the available memory is not considered low by the system.
@@ -828,7 +830,7 @@ public class Solo {
 
 	/**
 	 * Waits for a Dialog to open. Default timeout is 20 seconds.
-	 * 
+	 *
 	 * @return {@code true} if the {@link android.app.Dialog} is opened before the timeout and {@code false} if it is not opened
 	 */
 
@@ -838,7 +840,7 @@ public class Solo {
 
 	/**
 	 * Waits for a Dialog to close. Default timeout is 20 seconds.
-	 * 
+	 *
 	 * @return {@code true} if the {@link android.app.Dialog} is closed before the timeout and {@code false} if it is not closed
 	 */
 
@@ -848,7 +850,7 @@ public class Solo {
 
 	/**
 	 * Waits for a Dialog to open.
-	 * 
+	 *
 	 * @param timeout the amount of time in milliseconds to wait
 	 * @return {@code true} if the {@link android.app.Dialog} is opened before the timeout and {@code false} if it is not opened
 	 */
@@ -859,7 +861,7 @@ public class Solo {
 
 	/**
 	 * Waits for a Dialog to close.
-	 * 
+	 *
 	 * @param timeout the amount of time in milliseconds to wait
 	 * @return {@code true} if the {@link android.app.Dialog} is closed before the timeout and {@code false} if it is not closed
 	 */
@@ -932,7 +934,7 @@ public class Solo {
 
 
 	/**
-	 * Clicks a Button displaying the specified text. Will automatically scroll when needed. 
+	 * Clicks a Button displaying the specified text. Will automatically scroll when needed.
 	 *
 	 * @param text the text displayed by the {@link Button}. The parameter will be interpreted as a regular expression
 	 */
@@ -954,7 +956,7 @@ public class Solo {
 
 	/**
 	 * Clicks a ToggleButton displaying the specified text.
-	 * 
+	 *
 	 * @param text the text displayed by the {@link ToggleButton}. The parameter will be interpreted as a regular expression
 	 */
 
@@ -964,18 +966,18 @@ public class Solo {
 
 	/**
 	 * Clicks a MenuItem displaying the specified text.
-	 * 
+	 *
 	 * @param text the text displayed by the MenuItem. The parameter will be interpreted as a regular expression
 	 */
 
 	public void clickOnMenuItem(String text)
-	{	
+	{
 		clicker.clickOnMenuItem(text);
 	}
 
 	/**
 	 * Clicks a MenuItem displaying the specified text.
-	 * 
+	 *
 	 * @param text the text displayed by the MenuItem. The parameter will be interpreted as a regular expression
 	 * @param subMenu {@code true} if the menu item could be located in a sub menu
 	 */
@@ -987,7 +989,7 @@ public class Solo {
 
 	/**
 	 * Clicks the specified WebElement.
-	 * 
+	 *
 	 * @param webElement the WebElement to click
 	 */
 
@@ -1000,7 +1002,7 @@ public class Solo {
 
 	/**
 	 * Clicks a WebElement matching the specified By object.
-	 * 
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
 	 */
 
@@ -1010,7 +1012,7 @@ public class Solo {
 
 	/**
 	 * Clicks a WebElement matching the specified By object.
-	 * 
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
 	 * @param match if multiple objects match, this determines which one to click
 	 */
@@ -1021,7 +1023,7 @@ public class Solo {
 
 	/**
 	 * Clicks a WebElement matching the specified By object.
-	 * 
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
 	 * @param match if multiple objects match, this determines which one to click
 	 * @param scroll {@code true} if scrolling should be performed
@@ -1035,37 +1037,37 @@ public class Solo {
 	 * Presses a MenuItem matching the specified index. Index {@code 0} is the first item in the
 	 * first row, Index {@code 3} is the first item in the second row and
 	 * index {@code 6} is the first item in the third row.
-	 * 
+	 *
 	 * @param index the index of the {@link android.view.MenuItem} to press
 	 */
 
-	public void pressMenuItem(int index) {	
+	public void pressMenuItem(int index) {
 		presser.pressMenuItem(index);
 	}
 
 	/**
 	 * Presses a MenuItem matching the specified index. Supports three rows with a specified amount
-	 * of items. If itemsPerRow equals 5 then index 0 is the first item in the first row, 
+	 * of items. If itemsPerRow equals 5 then index 0 is the first item in the first row,
 	 * index 5 is the first item in the second row and index 10 is the first item in the third row.
-	 * 
+	 *
 	 * @param index the index of the {@link android.view.MenuItem} to press
-	 * @param itemsPerRow the amount of menu items there are per row   
+	 * @param itemsPerRow the amount of menu items there are per row
 	 */
 
-	public void pressMenuItem(int index, int itemsPerRow) {	
+	public void pressMenuItem(int index, int itemsPerRow) {
 		presser.pressMenuItem(index, itemsPerRow);
 	}
 
 	/**
-	 * Presses the soft keyboard next button. 
+	 * Presses the soft keyboard next button.
 	 */
 
 	public void pressSoftKeyboardNextButton(){
 		presser.pressSoftKeyboardSearchOrNextButton(false);
 	}
-	
+
 	/**
-	 * Presses the soft keyboard search button. 
+	 * Presses the soft keyboard search button.
 	 */
 
 	public void pressSoftKeyboardSearchButton(){
@@ -1074,16 +1076,16 @@ public class Solo {
 
 	/**
 	 * Presses a Spinner (drop-down menu) item.
-	 * 
+	 *
 	 * @param spinnerIndex the index of the {@link Spinner} menu to use
-	 * @param itemIndex the index of the {@link Spinner} item to press relative to the currently selected item. 
-	 * A Negative number moves up on the {@link Spinner}, positive moves down 
+	 * @param itemIndex the index of the {@link Spinner} item to press relative to the currently selected item.
+	 * A Negative number moves up on the {@link Spinner}, positive moves down
 	 */
 
 	public void pressSpinnerItem(int spinnerIndex, int itemIndex)
 	{
 		presser.pressSpinnerItem(spinnerIndex, itemIndex);
-	} 
+	}
 
 	/**
 	 * Clicks the specified View.
@@ -1098,7 +1100,7 @@ public class Solo {
 
 	/**
 	 * Clicks the specified View.
-	 * 
+	 *
 	 * @param view the {@link View} to click
 	 * @param immediately {@code true} if View should be clicked without any wait
 	 */
@@ -1122,7 +1124,7 @@ public class Solo {
 		view = waiter.waitForView(view, Timeout.getSmallTimeout());
 		clicker.clickOnScreen(view, true, 0);
 
-	}	
+	}
 
 	/**
 	 * Long clicks the specified View for a specified amount of time.
@@ -1138,7 +1140,7 @@ public class Solo {
 
 	/**
 	 * Clicks a View or WebElement displaying the specified
-	 * text. Will automatically scroll when needed. 
+	 * text. Will automatically scroll when needed.
 	 *
 	 * @param text the text to click. The parameter will be interpreted as a regular expression
 	 */
@@ -1152,7 +1154,7 @@ public class Solo {
 	 *
 	 * @param text the text to click. The parameter will be interpreted as a regular expression
 	 * @param match if multiple objects match the text, this determines which one to click
-	 */	
+	 */
 
 	public void clickOnText(String text, int match) {
 		clicker.clickOnText(text, false, match, true, 0);
@@ -1171,7 +1173,7 @@ public class Solo {
 	}
 
 	/**
-	 * Long clicks a View or WebElement displaying the specified text. Will automatically scroll when needed. 
+	 * Long clicks a View or WebElement displaying the specified text. Will automatically scroll when needed.
 	 *
 	 * @param text the text to click. The parameter will be interpreted as a regular expression
 	 */
@@ -1207,11 +1209,11 @@ public class Solo {
 	}
 
 	/**
-	 * Long clicks a View or WebElement displaying the specified text. 
+	 * Long clicks a View or WebElement displaying the specified text.
 	 *
 	 * @param text the text to click. The parameter will be interpreted as a regular expression
 	 * @param match if multiple objects match the text, this determines which one to click
-	 * @param time the amount of time to long click 
+	 * @param time the amount of time to long click
 	 */
 
 	public void clickLongOnText(String text, int match, int time)
@@ -1221,7 +1223,7 @@ public class Solo {
 
 	/**
 	 * Long clicks a View displaying the specified text and then selects
-	 * an item from the context menu that appears. Will automatically scroll when needed. 
+	 * an item from the context menu that appears. Will automatically scroll when needed.
 	 *
 	 * @param text the text to click. The parameter will be interpreted as a regular expression
 	 * @param index the index of the menu item to press. {@code 0} if only one is available
@@ -1245,7 +1247,7 @@ public class Solo {
 	 * Clicks a RadioButton matching the specified index.
 	 *
 	 * @param index the index of the {@link RadioButton} to click. {@code 0} if only one is available
-	 */	
+	 */
 
 	public void clickOnRadioButton(int index) {
 		clicker.clickOn(RadioButton.class, index);
@@ -1255,7 +1257,7 @@ public class Solo {
 	 * Clicks a CheckBox matching the specified index.
 	 *
 	 * @param index the index of the {@link CheckBox} to click. {@code 0} if only one is available
-	 */	
+	 */
 
 	public void clickOnCheckBox(int index) {
 		clicker.clickOn(CheckBox.class, index);
@@ -1274,7 +1276,7 @@ public class Solo {
 	/**
 	 * Clicks the specified list line and returns an ArrayList of the TextView objects that
 	 * the list line is displaying. Will use the first ListView it finds.
-	 * 
+	 *
 	 * @param line the line to click
 	 * @return an {@code ArrayList} of the {@link TextView} objects located in the list line
 	 */
@@ -1284,9 +1286,9 @@ public class Solo {
 	}
 
 	/**
-	 * Clicks the specified list line in the ListView matching the specified index and 
+	 * Clicks the specified list line in the ListView matching the specified index and
 	 * returns an ArrayList of the TextView objects that the list line is displaying.
-	 * 
+	 *
 	 * @param line the line to click
 	 * @param index the index of the list. {@code 0} if only one is available
 	 * @return an {@code ArrayList} of the {@link TextView} objects located in the list line
@@ -1299,7 +1301,7 @@ public class Solo {
 	/**
 	 * Long clicks the specified list line and returns an ArrayList of the TextView objects that
 	 * the list line is displaying. Will use the first ListView it finds.
-	 * 
+	 *
 	 * @param line the line to click
 	 * @return an {@code ArrayList} of the {@link TextView} objects located in the list line
 	 */
@@ -1309,9 +1311,9 @@ public class Solo {
 	}
 
 	/**
-	 * Long clicks the specified list line in the ListView matching the specified index and 
+	 * Long clicks the specified list line in the ListView matching the specified index and
 	 * returns an ArrayList of the TextView objects that the list line is displaying.
-	 * 
+	 *
 	 * @param line the line to click
 	 * @param index the index of the list. {@code 0} if only one is available
 	 * @return an {@code ArrayList} of the {@link TextView} objects located in the list line
@@ -1322,9 +1324,9 @@ public class Solo {
 	}
 
 	/**
-	 * Long clicks the specified list line in the ListView matching the specified index and 
+	 * Long clicks the specified list line in the ListView matching the specified index and
 	 * returns an ArrayList of the TextView objects that the list line is displaying.
-	 * 
+	 *
 	 * @param line the line to click
 	 * @param index the index of the list. {@code 0} if only one is available
 	 * @param time the amount of time to long click
@@ -1337,7 +1339,7 @@ public class Solo {
 
 	/**
 	 * Clicks an ActionBarItem matching the specified resource id.
-	 * 
+	 *
 	 * @param id the R.id of the ActionBar item to click
 	 */
 
@@ -1359,6 +1361,25 @@ public class Solo {
 	}
 
 	/**
+	* An Builder pattern that will allow the client to build a new illustration
+	*/
+
+	public Illustration.Builder createIllustrationBuilder(){
+		return new Illustration.Builder();
+	}
+
+  /**
+	 * Simulate drawing an illustration on the screen
+	 *
+	 * @param illustration Built-up illustration containing toolType, pressure, and
+	 * 				coordinate information.
+	 */
+
+	public void illustrate(Illustration illustration){
+		illustrator.illustrate(illustration);
+	}
+
+	/**
 	 * Simulate touching the specified location and dragging it to a new location.
 	 *
 	 *
@@ -1369,7 +1390,7 @@ public class Solo {
 	 * @param stepCount how many move steps to include in the drag. Less steps results in a faster drag
 	 */
 
-	public void drag(float fromX, float toX, float fromY, float toY, 
+	public void drag(float fromX, float toX, float fromY, float toY,
 			int stepCount) {
 		dialogUtils.hideSoftKeyboard(null, false, true);
 		scroller.drag(fromX, toX, fromY, toY, stepCount);
@@ -1385,7 +1406,7 @@ public class Solo {
 	@SuppressWarnings("unchecked")
 	public boolean scrollDown() {
 		View recyclerView = scroller.getRecyclerView(null);
-		
+
 		if(recyclerView != null){
 			waiter.waitForViews(true, AbsListView.class, ScrollView.class, WebView.class, recyclerView.getClass());
 		}
@@ -1416,7 +1437,7 @@ public class Solo {
 	 * Scrolls up the screen.
 	 *
 	 * @return {@code true} if more scrolling can be performed and {@code false} if it is at the top of
-	 * the screen 
+	 * the screen
 	 */
 
 	@SuppressWarnings("unchecked")
@@ -1433,7 +1454,7 @@ public class Solo {
 
 	/**
 	 * Scrolls to the top of the screen.
-	 */	
+	 */
 
 	@SuppressWarnings("unchecked")
 	public void scrollToTop() {
@@ -1449,7 +1470,7 @@ public class Solo {
 
 	/**
 	 * Scrolls down the specified AbsListView.
-	 * 
+	 *
 	 * @param list the {@link AbsListView} to scroll
 	 * @return {@code true} if more scrolling can be performed
 	 */
@@ -1471,7 +1492,7 @@ public class Solo {
 
 	/**
 	 * Scrolls up the specified AbsListView.
-	 * 
+	 *
 	 * @param list the {@link AbsListView} to scroll
 	 * @return {@code true} if more scrolling can be performed
 	 */
@@ -1493,7 +1514,7 @@ public class Solo {
 
 	/**
 	 * Scrolls down a ListView matching the specified index.
-	 * 
+	 *
 	 * @param index the index of the {@link ListView} to scroll. {@code 0} if only one list is available
 	 * @return {@code true} if more scrolling can be performed
 	 */
@@ -1515,7 +1536,7 @@ public class Solo {
 
 	/**
 	 * Scrolls up a ListView matching the specified index.
-	 * 
+	 *
 	 * @param index the index of the {@link ListView} to scroll. {@code 0} if only one list is available
 	 * @return {@code true} if more scrolling can be performed
 	 */
@@ -1536,18 +1557,18 @@ public class Solo {
 	}
 
 	/**
-	 * Scroll the specified AbsListView to the specified line. 
+	 * Scroll the specified AbsListView to the specified line.
 	 *
 	 * @param absListView the {@link AbsListView} to scroll
 	 * @param line the line to scroll to
-	 */	
+	 */
 
 	public void scrollListToLine(AbsListView absListView, int line){
 		scroller.scrollListToLine(absListView, line);
 	}
 
 	/**
-	 * Scroll a AbsListView matching the specified index to the specified line. 
+	 * Scroll a AbsListView matching the specified index to the specified line.
 	 *
 	 * @param index the index of the {@link AbsListView} to scroll
 	 * @param line the line to scroll to
@@ -1556,7 +1577,7 @@ public class Solo {
 	public void scrollListToLine(int index, int line){
 		scroller.scrollListToLine(waiter.waitForAndGetView(index, AbsListView.class), line);
 	}
-	
+
 	/**
 	 * Scrolls horizontally.
 	 *
@@ -1592,7 +1613,7 @@ public class Solo {
 	public void scrollToSide(int side) {
 		scrollToSide(side, 0.75F);
 	}
-	
+
 	/**
 	 * Scrolls a View horizontally.
 	 *
@@ -1636,7 +1657,7 @@ public class Solo {
 
 	/**
 	 * Zooms in or out if startPoint1 and startPoint2 are larger or smaller then endPoint1 and endPoint2. Requires API level >= 14.
-	 * 
+	 *
 	 * @param startPoint1 First "finger" down on the screen
 	 * @param startPoint2 Second "finger" down on the screen
 	 * @param endPoint1 Corresponding ending point of startPoint1
@@ -1653,7 +1674,7 @@ public class Solo {
 
 	/**
 	 * Swipes with two fingers in a linear path determined by starting and ending points. Requires API level >= 14.
-	 * 
+	 *
 	 * @param startPoint1 First "finger" down on the screen
 	 * @param startPoint2 Second "finger" down on the screen
 	 * @param endPoint1 Corresponding ending point of startPoint1
@@ -1671,7 +1692,7 @@ public class Solo {
 
 	/**
 	 * Draws two semi-circles at the specified centers. Both circles are larger than rotateSmall(). Requires API level >= 14.
-	 * 
+	 *
 	 * @param center1 Center of semi-circle drawn from [0, Pi]
 	 * @param center2 Center of semi-circle drawn from [Pi, 3*Pi]
 	 */
@@ -1686,10 +1707,10 @@ public class Solo {
 
 	/**
 	 * Draws two semi-circles at the specified centers. Both circles are smaller than rotateLarge(). Requires API level >= 14.
-	 * 
+	 *
 	 * @param center1 Center of semi-circle drawn from [0, Pi]
 	 * @param center2 Center of semi-circle drawn from [Pi, 3*Pi]
-	 */	
+	 */
 
 	public void rotateSmall(PointF center1, PointF center2)
 	{
@@ -1698,29 +1719,29 @@ public class Solo {
 		}
 		rotator.generateRotateGesture(Rotator.SMALL, center1, center2);
 	}
-	
+
 	/**
 	 * Sets if mobile data should be turned on or off. Requires android.permission.CHANGE_NETWORK_STATE in the AndroidManifest.xml of the application under test.
-	 * NOTE: Setting it to false can kill the adb connection. 
-	 * 
+	 * NOTE: Setting it to false can kill the adb connection.
+	 *
 	 * @param turnedOn true if mobile data is to be turned on and false if not
 	 */
 
 	public void setMobileData(Boolean turnedOn){
 		systemUtils.setMobileData(turnedOn);
 	}
-	
+
 	/**
-	 * Sets if wifi data should be turned on or off. Requires android.permission.CHANGE_WIFI_STATE in the AndroidManifest.xml of the application under test. 
-	 *  
-	 * 
+	 * Sets if wifi data should be turned on or off. Requires android.permission.CHANGE_WIFI_STATE in the AndroidManifest.xml of the application under test.
+	 *
+	 *
 	 * @param turnedOn true if mobile wifi is to be turned on and false if not
 	 */
 
 	public void setWiFiData(Boolean turnedOn){
 		systemUtils.setWiFiData(turnedOn);
 	}
-	
+
 
 	/**
 	 * Sets the date in a DatePicker matching the specified index.
@@ -1757,7 +1778,7 @@ public class Solo {
 	 * @param minute the minute e.g. 30
 	 */
 
-	public void setTimePicker(int index, int hour, int minute) {		
+	public void setTimePicker(int index, int hour, int minute) {
 		setTimePicker(waiter.waitForAndGetView(index, TimePicker.class), hour, minute);
 	}
 
@@ -1778,7 +1799,7 @@ public class Solo {
 	 * Sets the progress of a ProgressBar matching the specified index. Examples of ProgressBars are: {@link android.widget.SeekBar} and {@link android.widget.RatingBar}.
 	 *
 	 * @param index the index of the {@link ProgressBar}
-	 * @param progress the progress to set the {@link ProgressBar} 
+	 * @param progress the progress to set the {@link ProgressBar}
 	 */
 
 	public void setProgressBar(int index, int progress){
@@ -1789,14 +1810,14 @@ public class Solo {
 	 * Sets the progress of the specified ProgressBar. Examples of ProgressBars are: {@link android.widget.SeekBar} and {@link android.widget.RatingBar}.
 	 *
 	 * @param progressBar the {@link ProgressBar}
-	 * @param progress the progress to set the {@link ProgressBar} 
+	 * @param progress the progress to set the {@link ProgressBar}
 	 */
 
 	public void setProgressBar(ProgressBar progressBar, int progress){
 		progressBar = (ProgressBar) waiter.waitForView(progressBar, Timeout.getSmallTimeout());
 		setter.setProgressBar(progressBar, progress);
 	}
-	
+
 	/**
 	 * Sets the status of the NavigationDrawer. Examples of status are: {@code Solo.CLOSED} and {@code Solo.OPENED}.
 	 *
@@ -1811,7 +1832,7 @@ public class Solo {
 	 * Sets the status of a SlidingDrawer matching the specified index. Examples of status are: {@code Solo.CLOSED} and {@code Solo.OPENED}.
 	 *
 	 * @param index the index of the {@link SlidingDrawer}
-	 * @param status the status to set the {@link SlidingDrawer} 
+	 * @param status the status to set the {@link SlidingDrawer}
 	 */
 
 	public void setSlidingDrawer(int index, int status){
@@ -1822,7 +1843,7 @@ public class Solo {
 	 * Sets the status of the specified SlidingDrawer. Examples of status are: {@code Solo.CLOSED} and {@code Solo.OPENED}.
 	 *
 	 * @param slidingDrawer the {@link SlidingDrawer}
-	 * @param status the status to set the {@link SlidingDrawer} 
+	 * @param status the status to set the {@link SlidingDrawer}
 	 */
 
 	@SuppressWarnings("deprecation")
@@ -1830,7 +1851,7 @@ public class Solo {
 		slidingDrawer = (SlidingDrawer) waiter.waitForView(slidingDrawer, Timeout.getSmallTimeout());
 		setter.setSlidingDrawer(slidingDrawer, status);
 	}
-		
+
 	/**
 	 * Enters text in an EditText matching the specified index.
 	 *
@@ -1839,7 +1860,7 @@ public class Solo {
 	 */
 
 	public void enterText(int index, String text) {
-		textEnterer.setEditText(waiter.waitForAndGetView(index, EditText.class), text);		
+		textEnterer.setEditText(waiter.waitForAndGetView(index, EditText.class), text);
 	}
 
 	/**
@@ -1851,12 +1872,12 @@ public class Solo {
 
 	public void enterText(EditText editText, String text) {
 		editText = (EditText) waiter.waitForView(editText, Timeout.getSmallTimeout());
-		textEnterer.setEditText(editText, text);		
+		textEnterer.setEditText(editText, text);
 	}
 
 	/**
 	 * Enters text in a WebElement matching the specified By object.
-	 * 
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
 	 * @param text the text to enter in the {@link WebElement} field
 	 */
@@ -1876,7 +1897,7 @@ public class Solo {
 	 */
 
 	public void typeText(int index, String text) {
-		textEnterer.typeText(waiter.waitForAndGetView(index, EditText.class), text);		
+		textEnterer.typeText(waiter.waitForAndGetView(index, EditText.class), text);
 	}
 
 	/**
@@ -1888,12 +1909,12 @@ public class Solo {
 
 	public void typeText(EditText editText, String text) {
 		editText = (EditText) waiter.waitForView(editText, Timeout.getSmallTimeout());
-		textEnterer.typeText(editText, text);		
+		textEnterer.typeText(editText, text);
 	}
 
 	/**
 	 * Types text in a WebElement matching the specified By object.
-	 * 
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
 	 * @param text the text to enter in the {@link WebElement} field
 	 */
@@ -1904,7 +1925,7 @@ public class Solo {
 
 	/**
 	 * Types text in a WebElement matching the specified By object.
-	 * 
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
 	 * @param text the text to enter in the {@link WebElement} field
 	 * @param match if multiple objects match, this determines which one will be typed in
@@ -1918,7 +1939,7 @@ public class Solo {
 
 	/**
 	 * Types text in the specified WebElement.
-	 * 
+	 *
 	 * @param webElement the WebElement to type text in
 	 * @param text the text to enter in the {@link WebElement} field
 	 */
@@ -1931,7 +1952,7 @@ public class Solo {
 
 	/**
 	 * Clears the value of an EditText.
-	 * 
+	 *
 	 * @param index the index of the {@link EditText} to clear. 0 if only one is available
 	 */
 
@@ -1941,18 +1962,18 @@ public class Solo {
 
 	/**
 	 * Clears the value of an EditText.
-	 * 
+	 *
 	 * @param editText the {@link EditText} to clear
 	 */
 
 	public void clearEditText(EditText editText) {
 		editText = (EditText) waiter.waitForView(editText, Timeout.getSmallTimeout());
-		textEnterer.setEditText(editText, "");	
+		textEnterer.setEditText(editText, "");
 	}
 
 	/**
 	 * Clears text in a WebElement matching the specified By object.
-	 * 
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
 	 */
 
@@ -2026,8 +2047,8 @@ public class Solo {
 	}
 
 	/**
-	 * Returns a TextView displaying the specified text. 
-	 * 
+	 * Returns a TextView displaying the specified text.
+	 *
 	 * @param text the text that is displayed, specified as a regular expression
 	 * @return the {@link TextView} displaying the specified text
 	 */
@@ -2038,8 +2059,8 @@ public class Solo {
 	}
 
 	/**
-	 * Returns a TextView displaying the specified text. 
-	 * 
+	 * Returns a TextView displaying the specified text.
+	 *
 	 * @param text the text that is displayed, specified as a regular expression
 	 * @param onlyVisible {@code true} if only visible texts on the screen should be returned
 	 * @return the {@link TextView} displaying the specified text
@@ -2052,7 +2073,7 @@ public class Solo {
 
 	/**
 	 * Returns a Button displaying the specified text.
-	 * 
+	 *
 	 * @param text the text that is displayed, specified as a regular expression
 	 * @return the {@link Button} displaying the specified text
 	 */
@@ -2064,7 +2085,7 @@ public class Solo {
 
 	/**
 	 * Returns a Button displaying the specified text.
-	 * 
+	 *
 	 * @param text the text that is displayed, specified as a regular expression
 	 * @param onlyVisible {@code true} if only visible buttons on the screen should be returned
 	 * @return the {@link Button} displaying the specified text
@@ -2077,7 +2098,7 @@ public class Solo {
 
 	/**
 	 * Returns an EditText displaying the specified text.
-	 * 
+	 *
 	 * @param text the text that is displayed, specified as a regular expression
 	 * @return the {@link EditText} displaying the specified text
 	 */
@@ -2089,7 +2110,7 @@ public class Solo {
 
 	/**
 	 * Returns an EditText displaying the specified text.
-	 * 
+	 *
 	 * @param text the text that is displayed, specified as a regular expression
 	 * @param onlyVisible {@code true} if only visible EditTexts on the screen should be returned
 	 * @return the {@link EditText} displaying the specified text
@@ -2101,10 +2122,10 @@ public class Solo {
 	}
 
 	/**
-	 * Returns a View matching the specified resource id. 
-	 * 
+	 * Returns a View matching the specified resource id.
+	 *
 	 * @param id the R.id of the {@link View} to return
-	 * @return a {@link View} matching the specified id 
+	 * @return a {@link View} matching the specified id
 	 */
 
 	public View getView(int id){
@@ -2112,8 +2133,8 @@ public class Solo {
 	}
 
 	/**
-	 * Returns a View matching the specified resource id and index. 
-	 * 
+	 * Returns a View matching the specified resource id and index.
+	 *
 	 * @param id the R.id of the {@link View} to return
 	 * @param index the index of the {@link View}. {@code 0} if only one is available
 	 * @return a {@link View} matching the specified id and index
@@ -2171,8 +2192,8 @@ public class Solo {
 	}
 
 	/**
-	 * Returns a View matching the specified resource id. 
-	 * 
+	 * Returns a View matching the specified resource id.
+	 *
 	 * @param id the id of the {@link View} to return
 	 * @return a {@link View} matching the specified id
 	 */
@@ -2182,8 +2203,8 @@ public class Solo {
 	}
 
 	/**
-	 * Returns a View matching the specified resource id and index. 
-	 * 
+	 * Returns a View matching the specified resource id and index.
+	 *
 	 * @param id the id of the {@link View} to return
 	 * @param index the index of the {@link View}. {@code 0} if only one is available
 	 * @return a {@link View} matching the specified id and index
@@ -2205,11 +2226,11 @@ public class Solo {
 	}
 
 	/**
-	 * Returns a View matching the specified class and index. 
-	 * 
+	 * Returns a View matching the specified class and index.
+	 *
 	 * @param viewClass the class of the requested view
 	 * @param index the index of the {@link View}. {@code 0} if only one is available
-	 * @return a {@link View} matching the specified class and index 
+	 * @return a {@link View} matching the specified class and index
 	 */
 
 	public <T extends View> T getView(Class<T> viewClass, int index){
@@ -2218,7 +2239,7 @@ public class Solo {
 
 	/**
 	 * Returns a WebElement matching the specified By object and index.
-	 * 
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
 	 * @param index the index of the {@link WebElement}. {@code 0} if only one is available
 	 * @return a {@link WebElement} matching the specified index
@@ -2241,7 +2262,7 @@ public class Solo {
 
 	/**
 	 * Returns the current web page URL.
-	 * 
+	 *
 	 * @return the current web page URL
 	 */
 
@@ -2264,7 +2285,7 @@ public class Solo {
 	 *
 	 * @return an {@code ArrayList} of the {@link View} objects currently displayed in the
 	 * focused window
-	 */	
+	 */
 
 	public ArrayList<View> getCurrentViews() {
 		return viewFetcher.getViews(null, true);
@@ -2316,12 +2337,12 @@ public class Solo {
 	public <T extends View> ArrayList<T> getCurrentViews(Class<T> classToFilterBy, boolean includeSubclasses, View parent) {
 		return viewFetcher.getCurrentViews(classToFilterBy, includeSubclasses, parent);
 	}
-	
+
 	/**
 	 * Returns an ArrayList of all the WebElements displayed in the active WebView.
-	 * 
+	 *
 	 * @return an {@code ArrayList} of all the {@link WebElement} objects currently displayed in the active WebView
-	 */	
+	 */
 
 	public ArrayList<WebElement> getWebElements(){
 		return webUtils.getWebElements(false);
@@ -2329,10 +2350,10 @@ public class Solo {
 
 	/**
 	 * Returns an ArrayList of all the WebElements displayed in the active WebView matching the specified By object.
-	 * 
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
-	 * @return an {@code ArrayList} of all the {@link WebElement} objects displayed in the active WebView 
-	 */	
+	 * @return an {@code ArrayList} of all the {@link WebElement} objects displayed in the active WebView
+	 */
 
 	public ArrayList<WebElement> getWebElements(By by){
 		return webUtils.getWebElements(by, false);
@@ -2340,9 +2361,9 @@ public class Solo {
 
 	/**
 	 * Returns an ArrayList of the currently displayed WebElements in the active WebView.
-	 * 
+	 *
 	 * @return an {@code ArrayList} of the {@link WebElement} objects displayed in the active WebView
-	 */	
+	 */
 
 	public ArrayList<WebElement> getCurrentWebElements(){
 		return webUtils.getWebElements(true);
@@ -2350,10 +2371,10 @@ public class Solo {
 
 	/**
 	 * Returns an ArrayList of the currently displayed WebElements in the active WebView matching the specified By object.
-	 * 
+	 *
 	 * @param by the By object. Examples are: {@code By.id("id")} and {@code By.name("name")}
-	 * @return an {@code ArrayList} of the {@link WebElement} objects currently displayed in the active WebView 
-	 */	
+	 * @return an {@code ArrayList} of the {@link WebElement} objects currently displayed in the active WebView
+	 */
 
 	public ArrayList<WebElement> getCurrentWebElements(By by){
 		return webUtils.getWebElements(by, true);
@@ -2364,7 +2385,7 @@ public class Solo {
 	 *
 	 * @param index of the {@link RadioButton} to check. {@code 0} if only one is available
 	 * @return {@code true} if {@link RadioButton} is checked and {@code false} if it is not checked
-	 */	
+	 */
 
 	public boolean isRadioButtonChecked(int index)
 	{
@@ -2385,10 +2406,10 @@ public class Solo {
 
 	/**
 	 * Checks if a CheckBox matching the specified index is checked.
-	 * 
+	 *
 	 * @param index of the {@link CheckBox} to check. {@code 0} if only one is available
 	 * @return {@code true} if {@link CheckBox} is checked and {@code false} if it is not checked
-	 */	
+	 */
 
 	public boolean isCheckBoxChecked(int index)
 	{
@@ -2409,7 +2430,7 @@ public class Solo {
 
 	/**
 	 * Checks if a ToggleButton matching the specified index is checked.
-	 * 
+	 *
 	 * @param index of the {@link ToggleButton} to check. {@code 0} if only one is available
 	 * @return {@code true} if {@link ToggleButton} is checked and {@code false} if it is not checked
 	 */
@@ -2464,7 +2485,7 @@ public class Solo {
 	}
 
 	/**
-	 * Checks if the specified text is selected in a Spinner matching the specified index. 
+	 * Checks if the specified text is selected in a Spinner matching the specified index.
 	 *
 	 * @param index the index of the spinner to check. {@code 0} if only one spinner is available
 	 * @param text the text that is expected to be selected, specified as a regular expression
@@ -2502,8 +2523,8 @@ public class Solo {
 
 	/**
 	 * Sends a key: Right, Left, Up, Down, Enter, Menu or Delete.
-	 * 
-	 * @param key the key to be sent. Use {@code Solo.}{@link #RIGHT}, {@link #LEFT}, {@link #UP}, {@link #DOWN}, 
+	 *
+	 * @param key the key to be sent. Use {@code Solo.}{@link #RIGHT}, {@link #LEFT}, {@link #UP}, {@link #DOWN},
 	 * {@link #ENTER}, {@link #MENU}, {@link #DELETE}
 	 */
 
@@ -2523,7 +2544,7 @@ public class Solo {
 	}
 
 	/**
-	 * Waits for an Activity matching the specified name. Default timeout is 20 seconds. 
+	 * Waits for an Activity matching the specified name. Default timeout is 20 seconds.
 	 *
 	 * @param name the name of the {@code Activity} to wait for. Example is: {@code "MyActivity"}
 	 * @return {@code true} if {@code Activity} appears before the timeout and {@code false} if it does not
@@ -2573,7 +2594,7 @@ public class Solo {
 
 	/**
 	 * Wait for the activity stack to be empty.
-	 * 
+	 *
 	 * @param timeout the amount of time in milliseconds to wait
 	 * @return {@code true} if activity stack is empty before the timeout and {@code false} if it is not
 	 */
@@ -2591,10 +2612,10 @@ public class Solo {
 
 	/**
 	 * Waits for a Fragment matching the specified tag. Default timeout is 20 seconds.
-	 * 
-	 * @param tag the name of the tag	
+	 *
+	 * @param tag the name of the tag
 	 * @return {@code true} if fragment appears and {@code false} if it does not appear before the timeout
-	 */	
+	 */
 
 	public boolean waitForFragmentByTag(String tag){
 		return waiter.waitForFragment(tag, 0, Timeout.getLargeTimeout());
@@ -2602,11 +2623,11 @@ public class Solo {
 
 	/**
 	 * Waits for a Fragment matching the specified tag.
-	 * 
-	 * @param tag the name of the tag	
+	 *
+	 * @param tag the name of the tag
 	 * @param timeout the amount of time in milliseconds to wait
 	 * @return {@code true} if fragment appears and {@code false} if it does not appear before the timeout
-	 */	
+	 */
 
 	public boolean waitForFragmentByTag(String tag, int timeout){
 		return waiter.waitForFragment(tag, 0, timeout);
@@ -2614,8 +2635,8 @@ public class Solo {
 
 	/**
 	 * Waits for a Fragment matching the specified resource id. Default timeout is 20 seconds.
-	 * 
-	 * @param id the R.id of the fragment	
+	 *
+	 * @param id the R.id of the fragment
 	 * @return {@code true} if fragment appears and {@code false} if it does not appear before the timeout
 	 */
 
@@ -2625,8 +2646,8 @@ public class Solo {
 
 	/**
 	 * Waits for a Fragment matching the specified resource id.
-	 * 
-	 * @param id the R.id of the fragment	
+	 *
+	 * @param id the R.id of the fragment
 	 * @param timeout the amount of time in milliseconds to wait
 	 * @return {@code true} if fragment appears and {@code false} if it does not appear before the timeout
 	 */
@@ -2638,10 +2659,10 @@ public class Solo {
 	/**
 	 * Waits for the specified log message to appear. Default timeout is 20 seconds.
 	 * Requires read logs permission (android.permission.READ_LOGS) in AndroidManifest.xml of the application under test.
-	 * 
+	 *
 	 * @param logMessage the log message to wait for
 	 * @return {@code true} if log message appears and {@code false} if it does not appear before the timeout
-	 * 
+	 *
 	 * @see clearLog()
 	 */
 
@@ -2652,11 +2673,11 @@ public class Solo {
 	/**
 	 * Waits for the specified log message to appear.
 	 * Requires read logs permission (android.permission.READ_LOGS) in AndroidManifest.xml of the application under test.
-	 * 
+	 *
 	 * @param logMessage the log message to wait for
 	 * @param timeout the amount of time in milliseconds to wait
 	 * @return {@code true} if log message appears and {@code false} if it does not appear before the timeout
-	 * 
+	 *
 	 * @see clearLog()
 	 */
 
@@ -2674,7 +2695,7 @@ public class Solo {
 
 	/**
 	 * Returns a localized String matching the specified resource id.
-	 * 
+	 *
 	 * @param id the R.id of the String
 	 * @return the localized String
 	 */
@@ -2686,7 +2707,7 @@ public class Solo {
 
 	/**
 	 * Returns a localized String matching the specified resource id.
-	 * 
+	 *
 	 * @param id the id of the String
 	 * @return the localized String
 	 */
@@ -2698,9 +2719,9 @@ public class Solo {
 
 	/**
 	 * Robotium will sleep for the specified time.
-	 * 
-	 * @param time the time in milliseconds that Robotium should sleep 
-	 */	
+	 *
+	 * @param time the time in milliseconds that Robotium should sleep
+	 */
 
 	public void sleep(int time)
 	{
@@ -2710,9 +2731,9 @@ public class Solo {
 	/**
 	 *
 	 * Finalizes the Solo object and removes the ActivityMonitor.
-	 * 
+	 *
 	 * @see #finishOpenedActivities() finishOpenedActivities() to close the activities that have been active
-	 */    	
+	 */
 
 	public void finalize() throws Throwable {
 		activityUtils.finalize();
@@ -2762,11 +2783,11 @@ public class Solo {
 	 * Takes a screenshot sequence and saves the images with the specified name prefix in the {@link Config} objects save path (default set to: /sdcard/Robotium-Screenshots/).
 	 *
 	 * The name prefix is appended with "_" + sequence_number for each image in the sequence,
-	 * where numbering starts at 0.  
+	 * where numbering starts at 0.
 	 *
 	 * Requires write permission (android.permission.WRITE_EXTERNAL_STORAGE) in AndroidManifest.xml of the application under test.
 	 *
-	 * At present multiple simultaneous screenshot sequences are not supported.  
+	 * At present multiple simultaneous screenshot sequences are not supported.
 	 * This method will throw an exception if stopScreenshotSequence() has not been
 	 * called to finish any prior sequences.
 	 * Calling this method is equivalend to calling startScreenshotSequence(name, 80, 400, 100);
@@ -2775,7 +2796,7 @@ public class Solo {
 	 */
 
 	public void startScreenshotSequence(String name) {
-		startScreenshotSequence(name, 
+		startScreenshotSequence(name,
 				80, // quality
 				400, // 400 ms frame delay
 				100); // max frames
@@ -2785,16 +2806,16 @@ public class Solo {
 	 * Takes a screenshot sequence and saves the images with the specified name prefix in the {@link Config} objects save path (default set to: /sdcard/Robotium-Screenshots/).
 	 *
 	 * The name prefix is appended with "_" + sequence_number for each image in the sequence,
-	 * where numbering starts at 0.  
+	 * where numbering starts at 0.
 	 *
-	 * Requires write permission (android.permission.WRITE_EXTERNAL_STORAGE) in the 
+	 * Requires write permission (android.permission.WRITE_EXTERNAL_STORAGE) in the
 	 * AndroidManifest.xml of the application under test.
 	 *
-	 * Taking a screenshot will take on the order of 40-100 milliseconds of time on the 
+	 * Taking a screenshot will take on the order of 40-100 milliseconds of time on the
 	 * main UI thread.  Therefore it is possible to mess up the timing of tests if
 	 * the frameDelay value is set too small.
 	 *
-	 * At present multiple simultaneous screenshot sequences are not supported.  
+	 * At present multiple simultaneous screenshot sequences are not supported.
 	 * This method will throw an exception if stopScreenshotSequence() has not been
 	 * called to finish any prior sequences.
 	 *
@@ -2810,8 +2831,8 @@ public class Solo {
 
 	/**
 	 * Causes a screenshot sequence to end.
-	 * 
-	 * If this method is not called to end a sequence and a prior sequence is still in 
+	 *
+	 * If this method is not called to end a sequence and a prior sequence is still in
 	 * progress, startScreenshotSequence() will throw an exception.
 	 */
 
@@ -2834,8 +2855,8 @@ public class Solo {
 	 *
 	 * There are two options to set the timeout. Set it using adb shell (requires root access):
 	 * <br><br>
-	 * 'adb shell setprop solo_large_timeout milliseconds' 
-	 * <br>  
+	 * 'adb shell setprop solo_large_timeout milliseconds'
+	 * <br>
 	 * 'adb shell setprop solo_small_timeout milliseconds'
 	 * <br>
 	 * Example: adb shell setprop solo_small_timeout 10000
@@ -2844,7 +2865,7 @@ public class Solo {
 	 *
 	 * @param property name of the property to read the timeout from
 	 * @param defaultValue default value for the timeout
-	 * @return timeout in milliseconds 
+	 * @return timeout in milliseconds
 	 */
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -2859,4 +2880,3 @@ public class Solo {
 		}
 	}
 }
-

--- a/robotium-solo/src/main/java/com/robotium/solo/Solo.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/Solo.java
@@ -1368,7 +1368,7 @@ public class Solo {
 		return new Illustration.Builder();
 	}
 
-  /**
+    /**
 	 * Simulate drawing an illustration on the screen
 	 *
 	 * @param illustration Built-up illustration containing toolType, pressure, and


### PR DESCRIPTION
The newly added `Solo.illustrate()` method will allow for drawing an arbitrary path on the screen using any of `MotionEvent`'s possible `TOOL_TYPE`s. This includes the ability to send stylus input with pressure, which is of great value in testing stylus actions versus finger actions in an application.

`Illustration`s are built using the nested `Builder` class, which allows for specifying a `TOOL_TYPE`, and an arbitrary amount of points. This builder can be created using `Solo.createIllustrationBuilder()`.

I decided to call this method `illustrate()`, but if this name doesn't work it can easily be refactored.