### PR TITLE
Identify DecorViews on Android 6.0 Fixes #786

### DIFF
--- a/robotium-solo/src/main/java/com/robotium/solo/ViewFetcher.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/ViewFetcher.java
@@ -133,14 +133,9 @@ class ViewFetcher {
 
 		for (int j = 0; j < views.length; j++) {
 			view = views[j];
-			if (view != null){ 
-				String nameOfClass = view.getClass().getName();
-				if(nameOfClass.equals("com.android.internal.policy.impl.PhoneWindow$DecorView") || nameOfClass
-						.equals("com.android.internal.policy.impl.MultiPhoneWindow$MultiPhoneDecorView") || 
-						nameOfClass.equals("com.android.internal.policy.PhoneWindow$DecorView")) {
-					decorViews[i] = view;
-					i++;
-				}
+			if (isDecorView(view)){ 
+				decorViews[i] = view;
+				i++;
 			}
 		}
 		return getRecentContainer(decorViews);
@@ -186,8 +181,7 @@ class ViewFetcher {
 
 			for (int j = 0; j < views.length; j++) {
 				view = views[j];
-				if (view != null && !(view.getClass().getName()
-						.equals("com.android.internal.policy.impl.PhoneWindow$DecorView"))) {
+				if (!isDecorView(view)) {
 					decorViews[i] = view;
 					i++;
 				}
@@ -196,6 +190,21 @@ class ViewFetcher {
 		return decorViews;
 	}
 
+	/**
+	 * Returns whether a view is a DecorView
+ 	 * @param view
+	 * @return true if view is a DecorView, false otherwise
+	 */
+	private boolean isDecorView(View view) {
+		if (view == null) {
+			return false;
+		}
+
+		final String nameOfClass = view.getClass().getName();
+		return (nameOfClass.equals("com.android.internal.policy.impl.PhoneWindow$DecorView") ||
+				nameOfClass.equals("com.android.internal.policy.impl.MultiPhoneWindow$MultiPhoneDecorView") ||
+				nameOfClass.equals("com.android.internal.policy.PhoneWindow$DecorView"));
+	}
 
 
 	/**


### PR DESCRIPTION
The DecorView class package has been changed into `com.android.internal.policy.PhoneWindow$DecorView` so check for that as well.

Without this updated check ViewFetcher::getNonDecorViews() returns the DecorViews and that ends up making having the scroller to basically scroll the views twice.

A good opportunity for a minimal refactor and have the DecorView check be done in a dedicated `ViewFetcher::isDecorView()`.

Let me know in the comments if the PR or the fix itself needs more work.

I refrained from adding `com.android.internal.policy.MultiPhoneWindow$MultiPhoneDecorView` to the check as well as I cannot test that.

Cheers!