### PR TITLE
Add options in Config class to configure the duration of Sleeper sleep and sleepMini

### DIFF
--- a/robotium-solo/src/main/java/com/robotium/solo/Sleeper.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/Sleeper.java
@@ -2,24 +2,40 @@ package com.robotium.solo;
 
 class Sleeper {
 
-	private final int PAUSE = 500;
-	private final int MINIPAUSE = 300;
+	private int pauseDuration;
+	private int miniPauseDuration;
+
+	private Sleeper() {
+
+	}
 
 	/**
-	 * Sleeps the current thread for a default pause length.
+	 * Constructs this object.
+	 *
+	 * @param pauseDuration pause duration used in {@code sleep}
+	 * @param miniPauseDuration pause duration used in {@code sleepMini}
+	 */
+
+	public Sleeper(int pauseDuration, int miniPauseDuration) {
+		this.pauseDuration = pauseDuration;
+		this.miniPauseDuration = miniPauseDuration;
+	}
+
+	/**
+	 * Sleeps the current thread for the pause length.
 	 */
 
 	public void sleep() {
-        sleep(PAUSE);
+        sleep(pauseDuration);
 	}
 
 
 	/**
-	 * Sleeps the current thread for a default mini pause length.
+	 * Sleeps the current thread for the mini pause length.
 	 */
 
 	public void sleepMini() {
-        sleep(MINIPAUSE);
+        sleep(miniPauseDuration);
 	}
 
 

--- a/robotium-solo/src/main/java/com/robotium/solo/Solo.java
+++ b/robotium-solo/src/main/java/com/robotium/solo/Solo.java
@@ -152,7 +152,7 @@ public class Solo {
 		
 		this.config = (config == null) ? new Config(): config;
 		this.instrumentation = instrumentation;
-		this.sleeper = new Sleeper();
+		this.sleeper = new Sleeper(config.sleepDuration, config.sleepMiniDuration);
 		this.sender = new Sender(instrumentation, sleeper);
 		this.activityUtils = new ActivityUtils(config, instrumentation, activity, sleeper);
 		this.viewFetcher = new ViewFetcher(instrumentation, sleeper);
@@ -261,7 +261,17 @@ public class Solo {
 		 */
 		
 		public String commandLoggingTag = "Robotium";
-		
+
+		/**
+		 * The sleep duration for the Sleeper sleep method. Default length is 500 milliseconds.
+		 */
+		public int sleepDuration = 500;
+
+		/**
+		 * The sleep duration for the Sleeper sleepMini method. Default length is 300 milliseconds.
+		 */
+		public int sleepMiniDuration = 300;
+
 	}
 
 	/**


### PR DESCRIPTION
This can currently be done with reflection, but it's pretty nasty. This would let me define custom durations for the sleep and sleepMini methods of the Sleeper class.

https://stackoverflow.com/questions/35928964/robotium-customize-pause-duration-in-sleeper-class

Unsure if we want to put the default values of Sleeper (500 ms and 300 ms) in the Sleeper class, have the Config class reference those, and make the default constructor public and use those defaults?